### PR TITLE
Add effective stats and gameplay updates

### DIFF
--- a/engine/internal/api/api.go
+++ b/engine/internal/api/api.go
@@ -58,14 +58,14 @@ type ClientConn interface {
 type Session struct {
 	Player       *engine.Player
 	Conn         ClientConn
-	CaptureID    string    // active capture session ID, empty if not recording
-	lastCmdTime  time.Time // rate limiting: last command timestamp
-	cmdCount     int       // rate limiting: commands in current window
+	CaptureID    string      // active capture session ID, empty if not recording
+	lastCmdTime  time.Time   // rate limiting: last command timestamp
+	cmdCount     int         // rate limiting: commands in current window
 	chatTimes    []time.Time // chat flood: timestamps of recent broadcasts
 	cmdTimes     []time.Time // command rate: sliding window for 10/10s limit
-	authFailures int        // auth attempt failures (disconnect after 3)
-	lastActivity time.Time  // idle timeout tracking
-	quitSent     bool       // QUIT already broadcast departure
+	authFailures int         // auth attempt failures (disconnect after 3)
+	lastActivity time.Time   // idle timeout tracking
+	quitSent     bool        // QUIT already broadcast departure
 }
 
 // wsConn wraps a gorilla WebSocket connection to implement ClientConn.
@@ -102,7 +102,6 @@ func (w *wsConn) Close() error {
 func (w *wsConn) RemoteAddr() string {
 	return w.conn.RemoteAddr().String()
 }
-
 
 // getClientIP extracts the real client IP from the request, preferring
 // Fly-Client-IP (set by Fly.io proxy), then X-Forwarded-For, then RemoteAddr.
@@ -490,7 +489,9 @@ func (s *Server) handleGameWS(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.connMu.Lock()
 		s.connsByIP[ip]--
-		if s.connsByIP[ip] <= 0 { delete(s.connsByIP, ip) }
+		if s.connsByIP[ip] <= 0 {
+			delete(s.connsByIP, ip)
+		}
 		s.connMu.Unlock()
 	}()
 
@@ -773,7 +774,9 @@ func (s *Server) handleGameWS(w http.ResponseWriter, r *http.Request) {
 			cutoff := now.Add(-10 * time.Second)
 			var recentCmds []time.Time
 			for _, t := range session.cmdTimes {
-				if t.After(cutoff) { recentCmds = append(recentCmds, t) }
+				if t.After(cutoff) {
+					recentCmds = append(recentCmds, t)
+				}
 			}
 			session.cmdTimes = append(recentCmds, now)
 			if len(session.cmdTimes) > 10 {
@@ -787,6 +790,10 @@ func (s *Server) handleGameWS(w http.ResponseWriter, r *http.Request) {
 			ctx := context.Background()
 			playerRoom := session.Player.RoomNumber
 			result := s.engine.ProcessCommand(ctx, session.Player, cmd.Input)
+			// Expire timed effects
+			timerMessages := s.engine.UpdatePlayerTimers(session.Player)
+			result.Messages = append(result.Messages, timerMessages...)
+
 			result.PlayerState = session.Player
 			result.PromptIndicators = session.Player.PromptIndicators()
 			s.sendResult(session, result)
@@ -812,7 +819,9 @@ func (s *Server) handleGameWS(w http.ResponseWriter, r *http.Request) {
 				cutoff := now.Add(-10 * time.Second)
 				var recent []time.Time
 				for _, t := range session.chatTimes {
-					if t.After(cutoff) { recent = append(recent, t) }
+					if t.After(cutoff) {
+						recent = append(recent, t)
+					}
 				}
 				session.chatTimes = recent
 				if len(session.chatTimes) >= 5 {

--- a/engine/internal/api/ssh.go
+++ b/engine/internal/api/ssh.go
@@ -766,6 +766,11 @@ func (s *Server) sshCommandLoop(ctx context.Context, session *Session, sc *sshCo
 		}
 
 		result := s.engine.ProcessCommand(ctx, session.Player, input)
+
+		// Expire timed effects
+		timerMessages := s.engine.UpdatePlayerTimers(session.Player)
+		result.Messages = append(result.Messages, timerMessages...)
+
 		result.PlayerState = session.Player
 		result.PromptIndicators = session.Player.PromptIndicators()
 		s.sendResult(session, result)

--- a/engine/internal/api/telnet.go
+++ b/engine/internal/api/telnet.go
@@ -28,14 +28,14 @@ const (
 	sbByte   = 250 // sub-negotiation begin
 	seByte   = 240 // sub-negotiation end
 
-	optEcho  = 1  // Echo
-	optSGA   = 3  // Suppress Go-Ahead
-	optTType = 24 // Terminal Type (MTTS)
-	optNAWS  = 31 // Negotiate About Window Size
-	optMSDP  = 69 // MUD Server Data Protocol
-	optMSSP  = 70 // MUD Server Status Protocol
-	optMCCP2 = 86 // MUD Client Compression Protocol v2
-	optMXP   = 91 // MUD eXtension Protocol
+	optEcho  = 1   // Echo
+	optSGA   = 3   // Suppress Go-Ahead
+	optTType = 24  // Terminal Type (MTTS)
+	optNAWS  = 31  // Negotiate About Window Size
+	optMSDP  = 69  // MUD Server Data Protocol
+	optMSSP  = 70  // MUD Server Status Protocol
+	optMCCP2 = 86  // MUD Client Compression Protocol v2
+	optMXP   = 91  // MUD eXtension Protocol
 	optGMCP  = 201 // Generic MUD Communication Protocol
 
 	// MSSP sub-negotiation
@@ -95,7 +95,7 @@ type telnetConn struct {
 	passwordMode bool
 
 	// MCCP2: compressed writer (nil until activated)
-	compWriter   *zlib.Writer
+	compWriter    *zlib.Writer
 	compActivated bool
 
 	// Server reference for MSSP player count
@@ -382,13 +382,13 @@ func (t *telnetConn) negotiate() {
 	// We switch to WILL ECHO only for password prompts
 	t.conn.Write([]byte{
 		iacByte, wontByte, optEcho, // Client handles echo (normal)
-		iacByte, willByte, optSGA,  // Suppress go-ahead
-		iacByte, doByte, optNAWS,   // Request terminal size
-		iacByte, willByte, optGMCP,  // Offer GMCP
+		iacByte, willByte, optSGA, // Suppress go-ahead
+		iacByte, doByte, optNAWS, // Request terminal size
+		iacByte, willByte, optGMCP, // Offer GMCP
 		iacByte, willByte, optMCCP2, // Offer MCCP2
-		iacByte, willByte, optMSSP,  // Offer MSSP
-		iacByte, willByte, optMSDP,  // Offer MSDP
-		iacByte, doByte, optMXP,     // Request MXP
+		iacByte, willByte, optMSSP, // Offer MSSP
+		iacByte, willByte, optMSDP, // Offer MSDP
+		iacByte, doByte, optMXP, // Request MXP
 	})
 
 	// Read and respond to client negotiation for up to 2 seconds
@@ -1491,6 +1491,11 @@ func (s *Server) telnetCommandLoop(ctx context.Context, session *Session, tc *te
 		}
 
 		result := s.engine.ProcessCommand(ctx, session.Player, input)
+
+		// Expire timed effects
+		timerMessages := s.engine.UpdatePlayerTimers(session.Player)
+		result.Messages = append(result.Messages, timerMessages...)
+
 		result.PlayerState = session.Player
 		result.PromptIndicators = session.Player.PromptIndicators()
 		s.sendResult(session, result)

--- a/engine/internal/engine/combat.go
+++ b/engine/internal/engine/combat.go
@@ -41,9 +41,9 @@ type CombatTarget struct {
 // Level increases when total build points reach 20 + 10*(level+1).
 
 var xpPerBP = []int{
-	0,     // level 0 (unused)
-	100, 200, 400, 600, 800, 1000, 1200, 1400, 1600, 2000,       // 1-10
-	2400, 2700, 3200, 4000, 4800, 5600, 6400, 7200, 8000, 8800,  // 11-20
+	0,                                                     // level 0 (unused)
+	100, 200, 400, 600, 800, 1000, 1200, 1400, 1600, 2000, // 1-10
+	2400, 2700, 3200, 4000, 4800, 5600, 6400, 7200, 8000, 8800, // 11-20
 	9600, 10400, 11200, 12000, 12800, 13600, 14400, 15200, 16000, 16800, // 21-30
 	17600, 18400, 19200, 20000, 20800, 21600, 22400, 23200, 24000, 24800, // 31-40
 	25600, 26400, 27200, 28000, 28800, 29600, 30400, 31200, 32000, 32800, // 41-50
@@ -293,9 +293,9 @@ func playerAttackRating(player *Player, weaponDef *gameworld.ItemDef) int {
 		rating += player.Skills[24] * 5 // Martial Arts +5 per rank
 	}
 	if weaponDef != nil && (weaponDef.Type == "BOW_WEAPON" || weaponDef.Type == "THROWN_WEAPON") {
-		rating += player.Agility / 5
+		rating += player.EffectiveStat(StatAgility) / 5
 	} else {
-		rating += player.Strength / 5
+		rating += player.EffectiveStat(StatStrength) / 5
 	}
 	switch player.Stance {
 	case StanceOffensive:
@@ -322,7 +322,7 @@ func playerDefenseRating(player *Player) int {
 	rating := 25
 	rating += player.Level * 3
 	rating += player.Skills[6] * 5 // Dodge & Parry: +5 per rank
-	rating += player.Agility / 5
+	rating += player.EffectiveStat(StatAgility) / 5
 	// Martial Arts defense bonus: +2 per rank if unarmed
 	if player.Wielded == nil {
 		rating += player.Skills[24] * 2
@@ -369,11 +369,11 @@ func playerDamage(player *Player, weaponDef *gameworld.ItemDef) int {
 	if weaponDef == nil {
 		if player.WolfForm {
 			// Wolf form: claw/bite — higher base damage
-			return rand.Intn(8) + 3 + player.Strength/10
+			return rand.Intn(8) + 3 + player.EffectiveStat(StatStrength)/10
 		}
 		// Martial Arts: +1 base damage per rank, +1 max damage per 2 ranks
 		maSkill := player.Skills[24]
-		baseDmg := rand.Intn(3+maSkill/2) + 1 + maSkill + player.Strength/20
+		baseDmg := rand.Intn(3+maSkill/2) + 1 + maSkill + player.EffectiveStat(StatStrength)/20
 		return baseDmg
 	}
 	maxDmg := weaponDef.Parameter1
@@ -382,9 +382,9 @@ func playerDamage(player *Player, weaponDef *gameworld.ItemDef) int {
 	}
 	dmg := rand.Intn(maxDmg) + 1
 	if weaponDef.Type == "BOW_WEAPON" || weaponDef.Type == "THROWN_WEAPON" {
-		dmg += player.Agility / 10
+		dmg += player.EffectiveStat(StatAgility) / 10
 	} else {
-		dmg += player.Strength / 10
+		dmg += player.EffectiveStat(StatStrength) / 10
 	}
 	if player.Stance == StanceBerserk {
 		dmg = dmg * 12 / 10
@@ -792,7 +792,10 @@ func (e *GameEngine) doAttackMonster(ctx context.Context, player *Player, target
 		rtSec := 5
 		player.RoundTimeExpiry = time.Now().Add(time.Duration(rtSec) * time.Second)
 		result.Messages = append(result.Messages, fmt.Sprintf("[Round: %d sec]", rtSec))
-		if player.Hidden { player.Hidden = false; result.Messages = append([]string{"You reveal yourself!"}, result.Messages...) }
+		if player.Hidden {
+			player.Hidden = false
+			result.Messages = append([]string{"You reveal yourself!"}, result.Messages...)
+		}
 		e.SavePlayer(ctx, player)
 		result.PlayerState = player
 		return result
@@ -913,9 +916,9 @@ func (e *GameEngine) doAttackMonster(ctx context.Context, player *Player, target
 
 	// Roundtime: base 5, reduced by quickness and Combat Maneuvering
 	rtSeconds := 5
-	if player.Quickness > 80 {
+	if player.EffectiveStat(StatQuickness) > 80 {
 		rtSeconds = 3
-	} else if player.Quickness > 50 {
+	} else if player.EffectiveStat(StatQuickness) > 50 {
 		rtSeconds = 4
 	}
 	// Combat Maneuvering: -1 sec per rank (from skills.txt)
@@ -1003,46 +1006,50 @@ func (e *GameEngine) monsterAttackPlayer(inst *MonsterInstance, def *gameworld.M
 		// Combat Maneuvering: 2% per rank chance to dodge special attack (max 95%)
 		combatManeuver := player.Skills[10]
 		dodgeChance := combatManeuver * 2
-		if dodgeChance > 95 { dodgeChance = 95 }
+		if dodgeChance > 95 {
+			dodgeChance = 95
+		}
 		if dodgeChance > 0 && rand.Intn(100) < dodgeChance {
 			playerMsgs = append(playerMsgs, fmt.Sprintf("%s%s uses a special attack, but you dodge it!", capArt, name))
 		} else {
-		specText := def.TextOverrides["TEXX"]
-		if specText != "" {
-			specText = strings.Replace(specText, "%s", capArt+name, 1)
-			specText = strings.Replace(specText, "%s", player.FirstName, 1)
-		} else {
-			specText = fmt.Sprintf("%s%s uses a special attack on %s!", capArt, name, player.FirstName)
-		}
+			specText := def.TextOverrides["TEXX"]
+			if specText != "" {
+				specText = strings.Replace(specText, "%s", capArt+name, 1)
+				specText = strings.Replace(specText, "%s", player.FirstName, 1)
+			} else {
+				specText = fmt.Sprintf("%s%s uses a special attack on %s!", capArt, name, player.FirstName)
+			}
 
-		armorPct := playerArmorPercent(player, e.items)
-		specDmg = applyArmor(specDmg, armorPct)
+			armorPct := playerArmorPercent(player, e.items)
+			specDmg = applyArmor(specDmg, armorPct)
 
-		// Endurance: 1% elemental damage reduction per rank (max 50%)
-		enduranceSkill := player.Skills[11]
-		if enduranceSkill > 0 && (specType == "Heat" || specType == "Cold" || specType == "Electric") {
-			reduction := enduranceSkill
-			if reduction > 50 { reduction = 50 }
-			specDmg = specDmg * (100 - reduction) / 100
-		}
-		_ = specType
+			// Endurance: 1% elemental damage reduction per rank (max 50%)
+			enduranceSkill := player.Skills[11]
+			if enduranceSkill > 0 && (specType == "Heat" || specType == "Cold" || specType == "Electric") {
+				reduction := enduranceSkill
+				if reduction > 50 {
+					reduction = 50
+				}
+				specDmg = specDmg * (100 - reduction) / 100
+			}
+			_ = specType
 
-		part := randomBodyPart("HUMAN")
-		severity := damageSeverity(specDmg)
-		player.BodyPoints -= specDmg
-		if player.BodyPoints < 0 {
-			player.BodyPoints = 0
-		}
+			part := randomBodyPart("HUMAN")
+			severity := damageSeverity(specDmg)
+			player.BodyPoints -= specDmg
+			if player.BodyPoints < 0 {
+				player.BodyPoints = 0
+			}
 
-		playerMsgs = append(playerMsgs, specText)
-		playerMsgs = append(playerMsgs, fmt.Sprintf(" %s burn to %s. [%d Damage]", severity, part, specDmg))
-		roomMsgs = append(roomMsgs, specText)
+			playerMsgs = append(playerMsgs, specText)
+			playerMsgs = append(playerMsgs, fmt.Sprintf(" %s burn to %s. [%d Damage]", severity, part, specDmg))
+			roomMsgs = append(roomMsgs, specText)
 
-		if player.BodyPoints <= 0 {
-			deathMsgs := e.handlePlayerDeath(player, name)
-			playerMsgs = append(playerMsgs, deathMsgs...)
-			return playerMsgs, roomMsgs
-		}
+			if player.BodyPoints <= 0 {
+				deathMsgs := e.handlePlayerDeath(player, name)
+				playerMsgs = append(playerMsgs, deathMsgs...)
+				return playerMsgs, roomMsgs
+			}
 		} // end else (didn't dodge)
 	}
 
@@ -1367,7 +1374,7 @@ func (e *GameEngine) doFlee(ctx context.Context, player *Player) *CommandResult 
 		return &CommandResult{Messages: []string{"There is nowhere to flee!"}}
 	}
 
-	fleeChance := 50 + player.Quickness/5 + player.Agility/10
+	fleeChance := 50 + player.EffectiveStat(StatQuickness)/5 + player.EffectiveStat(StatAgility)/10
 	if player.Position != 0 {
 		fleeChance -= 20
 	}

--- a/engine/internal/engine/crafting.go
+++ b/engine/internal/engine/crafting.go
@@ -63,7 +63,7 @@ func (e *GameEngine) doMineReal(ctx context.Context, player *Player) *CommandRes
 	}
 
 	// Success chance: base 30% + mining*5 + STR/10
-	chance := 30 + miningSkill*5 + player.Strength/10
+	chance := 30 + miningSkill*5 + player.EffectiveStat(StatStrength)/10
 	if chance > 90 {
 		chance = 90
 	}
@@ -478,35 +478,34 @@ func (e *GameEngine) doWork(ctx context.Context, player *Player, args []string) 
 		// Find matching material in inventory
 		materialIdx := -1
 		materialAdj := 0
+
+		// Search inventory for the material
 		for j, ii := range player.Inventory {
 			mDef := e.items[ii.Archetype]
 			if mDef == nil {
 				continue
 			}
-			if mDef.Type == "MATERIAL" || mDef.Type == "MATERIAL2" {
-				if mDef.Parameter2 == 8 || mDef.Parameter2 == 0 { // weaponsmithing material
-					mName := strings.ToLower(e.getItemNounName(mDef))
-					// Check both definition adjective and instance adjective
-					defAdj := ""
-					if mDef.Parameter1 > 0 {
-						defAdj = strings.ToLower(e.getAdjName(mDef.Parameter1))
-					}
-					instAdj := strings.ToLower(e.getAdjName(ii.Adj1))
-					if strings.Contains(mName, metal) || strings.Contains(defAdj, metal) ||
-						strings.Contains(instAdj, metal) || strings.HasPrefix(metal, defAdj) ||
-						strings.HasPrefix(metal, instAdj) {
-						materialIdx = j
-						if ii.Adj1 > 0 {
-							materialAdj = ii.Adj1 // prefer instance adjective
-						} else if mDef.Parameter1 > 0 {
-							materialAdj = mDef.Parameter1
-						}
-						break
-					}
+
+			// Check if it's a material for Weaponsmithing (Skill 8)
+			if (mDef.Type == "MATERIAL" || mDef.Type == "MATERIAL2" || mDef.Type == "MISC") && (mDef.Parameter2 == 8 || mDef.Parameter2 == 0) {
+
+				// Get the names for comparison
+				mNoun := strings.ToLower(e.getItemNounName(mDef)) // e.g., "metal"
+				instAdj := strings.ToLower(e.getAdjName(ii.Adj1)) // e.g., "copper"
+
+				// FLEXIBLE MATCHING:
+				// Check if the user's input matches the adjective, the noun, or the combined name
+				fullItemName := instAdj + " " + mNoun // e.g., "copper metal"
+
+				if metal == instAdj || metal == mNoun || metal == fullItemName ||
+					strings.Contains(fullItemName, metal) {
+
+					materialIdx = j
+					materialAdj = ii.Adj1
+					break
 				}
 			}
 		}
-
 		if materialIdx < 0 {
 			// Also accept the metal name directly as a known metal type
 			knownMetals := []string{"copper", "iron", "brass", "bronze", "steel", "truesteel", "randar", "elkyri"}
@@ -556,7 +555,6 @@ func (e *GameEngine) doWork(ctx context.Context, player *Player, args []string) 
 			RoomBroadcast: []string{fmt.Sprintf("%s works diligently at the forge.", player.FirstName)},
 			PlayerState:   player,
 		}
-
 	case 2: // Heated → Hammer
 		player.CraftingStep = 3
 		player.RoundTimeExpiry = time.Now().Add(15 * time.Second)

--- a/engine/internal/engine/engine.go
+++ b/engine/internal/engine/engine.go
@@ -110,36 +110,36 @@ type PlayerMessageFunc func(playerName string, messages []string)
 
 // GameEngine holds the loaded game world and processes commands.
 type GameEngine struct {
-	db              *mongo.Database
-	nouns           map[int]string
-	adjectives      map[int]string
-	monAdjs         map[int]string
-	items           map[int]*gameworld.ItemDef
-	rooms           map[int]*gameworld.Room
-	monsters        map[int]*gameworld.MonsterDef
-	startRoom       int
-	departRoom      int // safe room for DEPART (bump room)
-	sessions        SessionProvider
-	onRoomChange    RoomChangeCallback
-	roomBroadcast      RoomBroadcastFunc
-	localRoomBroadcast LocalRoomBroadcastFunc
-	sendToPlayer       PlayerMessageFunc
-	monsterMgr      *monsterManager
-	RegionWeather   map[int]int // region -> weather state
-	monsterLists         []gameworld.MonsterList         // base + current season MLISTs
-	baseMonsterLists     []gameworld.MonsterList         // always-loaded MLISTs
+	db                   *mongo.Database
+	nouns                map[int]string
+	adjectives           map[int]string
+	monAdjs              map[int]string
+	items                map[int]*gameworld.ItemDef
+	rooms                map[int]*gameworld.Room
+	monsters             map[int]*gameworld.MonsterDef
+	startRoom            int
+	departRoom           int // safe room for DEPART (bump room)
+	sessions             SessionProvider
+	onRoomChange         RoomChangeCallback
+	roomBroadcast        RoomBroadcastFunc
+	localRoomBroadcast   LocalRoomBroadcastFunc
+	sendToPlayer         PlayerMessageFunc
+	monsterMgr           *monsterManager
+	RegionWeather        map[int]int                        // region -> weather state
+	monsterLists         []gameworld.MonsterList            // base + current season MLISTs
+	baseMonsterLists     []gameworld.MonsterList            // always-loaded MLISTs
 	seasonalMonsterLists map[string][]gameworld.MonsterList // per-season MLISTs
 	seasonalRooms        map[string][]gameworld.Room        // per-season room overrides
 	currentSeason        string                             // current active season key
-	cevents         []gameworld.CEvent
-	forageDefs      []gameworld.ForageDef
-	PVals           map[int]int // persistent global values
-	NamedVars       map[string]int // VARIABLE-defined global named variables (DANWATER, etc.)
-	namedVarNames   map[string]bool // set of valid named variable names
-	Events          *EventBus
-	Banner          string // active login banner; in-memory so it works even if MongoDB is down
-	lastAssistName  string // last player who used ASSIST (for @answer)
-	lastAssistRoom  int    // room number of last ASSIST
+	cevents              []gameworld.CEvent
+	forageDefs           []gameworld.ForageDef
+	PVals                map[int]int     // persistent global values
+	NamedVars            map[string]int  // VARIABLE-defined global named variables (DANWATER, etc.)
+	namedVarNames        map[string]bool // set of valid named variable names
+	Events               *EventBus
+	Banner               string // active login banner; in-memory so it works even if MongoDB is down
+	lastAssistName       string // last player who used ASSIST (for @answer)
+	lastAssistRoom       int    // room number of last ASSIST
 }
 
 // SetSessionProvider sets the session provider (called by API layer after init).
@@ -212,16 +212,16 @@ func (e *GameEngine) saveBanner(text string) {
 
 // GMScript represents a GM-uploaded script stored in MongoDB.
 type GMScript struct {
-	Filename    string          `bson:"_id" json:"filename"`
-	Name        string          `bson:"name" json:"name"`
-	Content     string          `bson:"content" json:"content"`
-	Priority    int             `bson:"priority" json:"priority"` // higher = loads sooner
-	Size        int             `bson:"size" json:"size"`
-	UploadedBy  string          `bson:"uploadedBy" json:"uploadedBy"`
-	UploadedByAccountID string  `bson:"uploadedByAccountId" json:"uploadedByAccountId"`
-	UploadedAt  time.Time       `bson:"uploadedAt" json:"uploadedAt"`
-	ParseStats  ScriptApplyStats `bson:"parseStats" json:"parseStats"`
-	History     []GMScriptVersion `bson:"history" json:"history"`
+	Filename            string            `bson:"_id" json:"filename"`
+	Name                string            `bson:"name" json:"name"`
+	Content             string            `bson:"content" json:"content"`
+	Priority            int               `bson:"priority" json:"priority"` // higher = loads sooner
+	Size                int               `bson:"size" json:"size"`
+	UploadedBy          string            `bson:"uploadedBy" json:"uploadedBy"`
+	UploadedByAccountID string            `bson:"uploadedByAccountId" json:"uploadedByAccountId"`
+	UploadedAt          time.Time         `bson:"uploadedAt" json:"uploadedAt"`
+	ParseStats          ScriptApplyStats  `bson:"parseStats" json:"parseStats"`
+	History             []GMScriptVersion `bson:"history" json:"history"`
 }
 
 // GMScriptVersion is a historical version of a script.
@@ -357,10 +357,10 @@ func (e *GameEngine) parseAndApplyScript(content, filename string) (ScriptApplyS
 
 // ScriptApplyStats summarizes what a hot-loaded script changed.
 type ScriptApplyStats struct {
-	Rooms    int `json:"rooms"`
-	Items    int `json:"items"`
-	Monsters int `json:"monsters"`
-	Nouns    int `json:"nouns"`
+	Rooms     int `json:"rooms"`
+	Items     int `json:"items"`
+	Monsters  int `json:"monsters"`
+	Nouns     int `json:"nouns"`
 	Variables int `json:"variables"`
 }
 
@@ -663,7 +663,7 @@ type CommandResult struct {
 	CantMsg    string `json:"-"`
 	CantSender string `json:"-"`
 	// LogEvent: optional event to log (type, detail).
-	LogEventType string `json:"-"`
+	LogEventType   string `json:"-"`
 	LogEventDetail string `json:"-"`
 }
 
@@ -985,7 +985,9 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 			lvl := player.Skills[id]
 			if lvl > 0 {
 				name := SkillNames[id]
-				if name == "" { name = fmt.Sprintf("Skill #%d", id) }
+				if name == "" {
+					name = fmt.Sprintf("Skill #%d", id)
+				}
 				skillMsgs = append(skillMsgs, fmt.Sprintf("  %s: rank %d", name, lvl))
 				hasSkills = true
 			}
@@ -1203,7 +1205,9 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 		var selfMsgs, roomMsgs []string
 		for i, line := range lines {
 			line = strings.TrimSpace(line)
-			if line == "" { continue }
+			if line == "" {
+				continue
+			}
 			if i == 0 {
 				selfMsgs = append(selfMsgs, fmt.Sprintf("You recite, '%s", line))
 				roomMsgs = append(roomMsgs, fmt.Sprintf("%s recites, '%s", player.FirstName, line))
@@ -1230,7 +1234,7 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 		// Bare SEARCH: scan the area for hidden players
 		player.RoundTimeExpiry = time.Now().Add(5 * time.Second)
 		msgs := []string{"You search the area.", "[Round: 5 sec]"}
-		perceptionCheck := player.Perception + player.Skills[33]*5 // Stealth skill helps detection
+		perceptionCheck := player.EffectiveStat(StatPerception) + player.Skills[33]*5 // Stealth skill helps detection
 		var revealed []string
 		if e.sessions != nil {
 			for _, p := range e.sessions.OnlinePlayers() {
@@ -1334,13 +1338,19 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 	case "FLY":
 		return e.doFly(ctx, player)
 	case "ASCEND":
-		if player.Position != 4 { return &CommandResult{Messages: []string{"You must be flying to ascend."}} }
+		if player.Position != 4 {
+			return &CommandResult{Messages: []string{"You must be flying to ascend."}}
+		}
 		return e.doMove(ctx, player, "U")
 	case "DESCEND":
-		if player.Position != 4 { return &CommandResult{Messages: []string{"You must be flying to descend."}} }
+		if player.Position != 4 {
+			return &CommandResult{Messages: []string{"You must be flying to descend."}}
+		}
 		return e.doMove(ctx, player, "D")
 	case "LAND":
-		if player.Position != 4 { return &CommandResult{Messages: []string{"You aren't flying."}} }
+		if player.Position != 4 {
+			return &CommandResult{Messages: []string{"You aren't flying."}}
+		}
 		player.Position = 0
 		e.SavePlayer(ctx, player)
 		return &CommandResult{Messages: []string{"You land."}, RoomBroadcast: []string{fmt.Sprintf("%s lands.", player.FirstName)}}
@@ -1361,7 +1371,8 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 	case "SPELL":
 		return e.doSpellList(player)
 	case "UNPROMPT":
-		player.PromptMode = false; e.SavePlayer(ctx, player)
+		player.PromptMode = false
+		e.SavePlayer(ctx, player)
 		return &CommandResult{Messages: []string{"Prompt indicators off."}}
 	case "VERSION", "NEWS", "NOTES":
 		return &CommandResult{Messages: []string{"Legends of Future Past v11.5.11"}}
@@ -1510,6 +1521,7 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 		return e.doProjectPsi(ctx, player, args)
 	case "CHANT":
 		return e.doChant(ctx, player, args)
+
 	case "COMMAND":
 		return &CommandResult{Messages: []string{"[Summoned creature commands coming soon.]"}}
 	case "MASTER":
@@ -1531,6 +1543,8 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 		return &CommandResult{Messages: []string{"[Self-training coming soon.]"}} // TODO: train self at +1 cost
 	case "UNLEARN":
 		return e.doUnlearn(ctx, player, args)
+	case "LEARN":
+		return e.doLearn(ctx, player, args)
 	case "ANOINT":
 		return e.doAnoint(ctx, player, args)
 	case "TRAP":
@@ -1639,7 +1653,9 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 		reportText := strings.Join(strings.Fields(input)[1:], " ")
 		room := e.rooms[player.RoomNumber]
 		roomName := "unknown"
-		if room != nil { roomName = room.Name }
+		if room != nil {
+			roomName = room.Name
+		}
 		e.Events.Publish("report", fmt.Sprintf("[REPORT] %s (room %d %s): %s", player.FirstName, player.RoomNumber, roomName, reportText))
 		return &CommandResult{
 			Messages:       []string{"Your report has been filed. Thank you!"},
@@ -1674,6 +1690,58 @@ func (e *GameEngine) ProcessCommand(ctx context.Context, player *Player, input s
 	}
 }
 
+func (e *GameEngine) UpdatePlayerTimers(player *Player) []string {
+	var messages []string
+
+	messages = append(messages, e.RemoveExpiredStatEffects(player)...)
+
+	// Later:
+	// messages = append(messages, e.RemoveExpiredResistances(player)...)
+	// messages = append(messages, e.ProcessPoisonTicks(player)...)
+	// messages = append(messages, e.RemoveExpiredConditions(player)...)
+
+	return messages
+}
+
+func (e *GameEngine) RemoveExpiredStatEffects(player *Player) []string {
+	now := time.Now()
+
+	if len(player.ActiveStatEffects) == 0 {
+		return nil
+	}
+
+	var messages []string
+	active := player.ActiveStatEffects[:0]
+
+	for _, effect := range player.ActiveStatEffects {
+		if effect.ExpiresAt.After(now) {
+			active = append(active, effect)
+			continue
+		}
+
+		switch effect.Source {
+		case EffectSourceSpell:
+
+			if spell := FindSpellByID(effect.EffectID); spell != nil {
+				messages = append(messages,
+					fmt.Sprintf("The effects of %s wear off.", spell.Name))
+			} else {
+				messages = append(messages, "A magical effect wears off.")
+			}
+
+		case EffectSourcePotion:
+			messages = append(messages, "The effects of a potion wear off.")
+
+		default:
+			messages = append(messages, "An effect wears off.")
+		}
+	}
+
+	player.ActiveStatEffects = active
+
+	return messages
+}
+
 // allVerbs is the canonical list of all recognized command verbs.
 // Abbreviation resolution matches against this list.
 var allVerbs = []string{
@@ -1689,7 +1757,7 @@ var allVerbs = []string{
 	"FLIP", "LATCH", "UNLATCH",
 	"DEPOSIT", "WITHDRAW", "TRAIN",
 	"MINE", "FORAGE",
-	"CRAFT", "FORGE", "SMELT", "WEAVE", "DYE", "BREW", "ANALYZE", "WORK", "REPAIR",
+	"CRAFT", "FORGE", "SMELT", "WEAVE", "DYE", "BREW", "ANALYZE", "WORK", "REPAIR", "LEARN",
 	// Movement/stealth
 	"HIDE", "SNEAK", "FLY", "ASCEND", "DESCEND", "LAND",
 	// Interaction
@@ -1706,7 +1774,7 @@ var allVerbs = []string{
 	"NOCK", "LOAD", "SPECIALIZE",
 	// Skill-based (TODO: implement)
 	"DISARM", "STEAL", "FILCH", "ROB", "STALK",
-	"TEACH", "SELFTRAIN", "UNLEARN",
+	"TEACH", "SELFTRAIN", "UNLEARN", "LEARN",
 	"ANOINT", "POISON", "TRAP",
 	"SURVEY", "SPLIT",
 	// Racial (TODO: implement)
@@ -1764,7 +1832,7 @@ var verbAliases = map[string]string{
 	"INV": "INVENTORY", "STAT": "STATUS", "UNUSE": "UNWIELD",
 	"DON": "WEAR", "EXIT": "QUIT", "SKILL": "SKILLS",
 	"WHI": "WHISPER", "THIN": "THINK", "CONTA": "CONTACT",
-	"DI": "DIAGNOSE",
+	"DI":    "DIAGNOSE",
 	"ORDER": "BUY", "UNLIGHT": "EXTINGUISH", "IGNITE": "LIGHT",
 	"QUAFF": "DRINK", "SHOUT": "YELL", "A": "ATTACK",
 	"PLACE": "PUT", "TRANS": "TRANSFORM",
@@ -1861,7 +1929,7 @@ func (e *GameEngine) doMove(ctx context.Context, player *Player, dir string) *Co
 
 	player.RoomNumber = destNum
 	player.Submitting = false // moving clears submit state
-	e.disengageCombat(player)  // moving clears combat
+	e.disengageCombat(player) // moving clears combat
 
 	// Moving away from leader breaks follow
 	if player.Following != "" {
@@ -2328,7 +2396,10 @@ func (e *GameEngine) doLookAt(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, remaining, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			if prefix == "IN" && isContainer(itemDef) {
 				displayName := e.formatItemName(itemDef, ri.Adj1, ri.Adj2, ri.Adj3)
 				if ri.State == "OPEN" || ri.State == "" {
@@ -2347,7 +2418,9 @@ func (e *GameEngine) doLookAt(player *Player, args []string) *CommandResult {
 	allItems := make([]InventoryItem, 0, len(player.Inventory)+len(player.Worn)+1)
 	allItems = append(allItems, player.Inventory...)
 	allItems = append(allItems, player.Worn...)
-	if player.Wielded != nil { allItems = append(allItems, *player.Wielded) }
+	if player.Wielded != nil {
+		allItems = append(allItems, *player.Wielded)
+	}
 	for _, ii := range allItems {
 		itemDef := e.items[ii.Archetype]
 		if itemDef == nil {
@@ -2355,7 +2428,10 @@ func (e *GameEngine) doLookAt(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, remaining, e.getAdjName(ii.Adj1)) || matchesTarget(name, remaining, e.getAdjName(ii.Adj3)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			if prefix == "IN" && isContainer(itemDef) {
 				return e.lookInContainer(player, itemDef, &ii)
 			}
@@ -2363,11 +2439,27 @@ func (e *GameEngine) doLookAt(player *Player, args []string) *CommandResult {
 				displayName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 				return &CommandResult{Messages: []string{fmt.Sprintf("You see nothing noteworthy %s %s.", strings.ToLower(prefix), displayName)}}
 			}
-			return &CommandResult{Messages: []string{fmt.Sprintf("You look at your %s.", name)}}
+			msgs := []string{fmt.Sprintf("You look at your %s.", name)}
+			if sm := e.scrollLookMsg(ii.Archetype, ii.Val3); sm != "" {
+				msgs = append(msgs, sm)
+			}
+			return &CommandResult{Messages: msgs}
 		}
 	}
 
 	return &CommandResult{Messages: []string{"You don't see that here."}}
+}
+
+// scrollLookMsg returns a description line if the item is a scroll, empty string otherwise.
+func (e *GameEngine) scrollLookMsg(archetype int, val3 int) string {
+	if archetype != 168 {
+		return ""
+	}
+	spell := FindSpellByID(val3)
+	if spell != nil {
+		return fmt.Sprintf("The scroll contains the spell '%s' (spell #%d).", spell.Name, val3)
+	}
+	return fmt.Sprintf("The scroll contains spell #%d.", val3)
 }
 
 // findPlayerInRoom finds an online player in the same room by name (first name match).
@@ -2634,7 +2726,9 @@ func (e *GameEngine) doGo(ctx context.Context, player *Player, args []string) *C
 	if player.Position != 0 && player.Position != 4 {
 		posNames := map[int]string{1: "sitting", 2: "laying down", 3: "kneeling"}
 		posName := posNames[player.Position]
-		if posName == "" { posName = "not standing" }
+		if posName == "" {
+			posName = "not standing"
+		}
 		return &CommandResult{Messages: []string{fmt.Sprintf("You can't move while %s! Try STANDing first.", posName)}}
 	}
 
@@ -2667,7 +2761,10 @@ func (e *GameEngine) doGo(ctx context.Context, player *Player, args []string) *C
 		if !matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
 			continue
 		}
-		if skip > 0 { skip--; continue }
+		if skip > 0 {
+			skip--
+			continue
+		}
 		if isPortal(itemDef.Type) {
 			return e.doGoPortal(ctx, player, room, &room.Items[i], itemDef)
 		}
@@ -2803,7 +2900,9 @@ func (e *GameEngine) doClimb(ctx context.Context, player *Player, args []string)
 	if player.Position != 0 && player.Position != 4 {
 		posNames := map[int]string{1: "sitting", 2: "laying down", 3: "kneeling"}
 		posName := posNames[player.Position]
-		if posName == "" { posName = "not standing" }
+		if posName == "" {
+			posName = "not standing"
+		}
 		return &CommandResult{Messages: []string{fmt.Sprintf("You can't climb while %s! Try STANDing first.", posName)}}
 	}
 	target := strings.ToLower(strings.Join(args, " "))
@@ -2821,7 +2920,10 @@ func (e *GameEngine) doClimb(ctx context.Context, player *Player, args []string)
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			if isPortal(itemDef.Type) {
 				return e.doGoPortal(ctx, player, room, &room.Items[i], itemDef)
 			}
@@ -2881,7 +2983,10 @@ func (e *GameEngine) doItemInteraction(ctx context.Context, player *Player, verb
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			result := &CommandResult{}
 			// Run IFPREVERB scripts (room-level and item-level)
 			sc := e.RunPreverbScripts(player, room, verb, &room.Items[i], itemDef)
@@ -2943,7 +3048,10 @@ func (e *GameEngine) doItemInteraction(ctx context.Context, player *Player, verb
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) || matchesTarget(name, target, e.getAdjName(ii.Adj3)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			// Create a temporary RoomItem for script context
 			tempRI := gameworld.RoomItem{Ref: -1, Archetype: ii.Archetype,
 				Adj1: ii.Adj1, Adj2: ii.Adj2, Adj3: ii.Adj3,
@@ -2984,7 +3092,9 @@ func (e *GameEngine) doGet(ctx context.Context, player *Player, args []string) *
 		// Handle coin piles (State == "MONEY", may have Archetype 0)
 		if ri.State == "MONEY" && (target == "coins" || target == "money" || target == "coin" || target == "gold" || target == "silver" || target == "copper") {
 			coins := ri.Val1
-			if coins <= 0 { coins = 1 }
+			if coins <= 0 {
+				coins = 1
+			}
 			room.Items = append(room.Items[:i], room.Items[i+1:]...)
 			e.notifyRoomChange(RoomChange{RoomNumber: player.RoomNumber, Type: "item_remove", ItemRef: ri.Ref})
 			player.Copper += coins
@@ -3014,12 +3124,17 @@ func (e *GameEngine) doGet(ctx context.Context, player *Player, args []string) *
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 
 			// MONEY items auto-convert to currency
 			if itemDef.Type == "MONEY" || ri.State == "MONEY" {
 				coins := ri.Val1
-				if coins <= 0 { coins = 1 }
+				if coins <= 0 {
+					coins = 1
+				}
 				room.Items = append(room.Items[:i], room.Items[i+1:]...)
 				e.notifyRoomChange(RoomChange{RoomNumber: player.RoomNumber, Type: "item_remove", ItemRef: ri.Ref})
 				player.Copper += coins
@@ -3038,7 +3153,7 @@ func (e *GameEngine) doGet(ctx context.Context, player *Player, args []string) *
 			// Add to inventory
 			player.Inventory = append(player.Inventory, InventoryItem{
 				Archetype: ri.Archetype,
-				Adj1: ri.Adj1, Adj2: ri.Adj2, Adj3: ri.Adj3,
+				Adj1:      ri.Adj1, Adj2: ri.Adj2, Adj3: ri.Adj3,
 				Val1: ri.Val1, Val2: ri.Val2, Val3: ri.Val3, Val4: ri.Val4, Val5: ri.Val5,
 			})
 			// Remove from room
@@ -3075,11 +3190,14 @@ func (e *GameEngine) doDrop(ctx context.Context, player *Player, args []string) 
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			droppedItem := gameworld.RoomItem{
-				Ref: len(room.Items),
+				Ref:       len(room.Items),
 				Archetype: ii.Archetype,
-				Adj1: ii.Adj1, Adj2: ii.Adj2, Adj3: ii.Adj3,
+				Adj1:      ii.Adj1, Adj2: ii.Adj2, Adj3: ii.Adj3,
 				Val1: ii.Val1, Val2: ii.Val2, Val3: ii.Val3, Val4: ii.Val4, Val5: ii.Val5,
 			}
 			room.Items = append(room.Items, droppedItem)
@@ -3147,8 +3265,8 @@ func (e *GameEngine) doStatus(player *Player) *CommandResult {
 
 	msgs = append(msgs,
 		fmt.Sprintf("Name: %s   Race: %s   Gender: %s   Level: %d", player.FullName(), player.RaceName(), genderName(player.Gender), player.Level),
-		fmt.Sprintf("Strength: %d   Agility: %d   Quickness: %d", player.Strength, player.Agility, player.Quickness),
-		fmt.Sprintf("Constitution: %d   Perception: %d   Willpower: %d   Empathy: %d", player.Constitution, player.Perception, player.Willpower, player.Empathy),
+		fmt.Sprintf("Strength: %d   Agility: %d   Quickness: %d", player.EffectiveStat(StatStrength), player.EffectiveStat(StatAgility), player.EffectiveStat(StatQuickness)),
+		fmt.Sprintf("Constitution: %d   Perception: %d   Willpower: %d   Empathy: %d", player.EffectiveStat(StatConstitution), player.EffectiveStat(StatPerception), player.EffectiveStat(StatWillpower), player.EffectiveStat(StatEmpathy)),
 	)
 
 	// Build points
@@ -3189,9 +3307,103 @@ func (e *GameEngine) doStatus(player *Player) *CommandResult {
 		fmt.Sprintf("Load: %d lbs", loadWeight),
 	)
 
+	// Active temporary effects
+	now := time.Now()
+	activeEffectCount := 0
+
+	for _, effect := range player.ActiveStatEffects {
+		if !effect.ExpiresAt.After(now) {
+			continue
+		}
+
+		if activeEffectCount == 0 {
+			msgs = append(msgs, "Active Effects:")
+		}
+
+		name := "Unknown Effect"
+
+		switch effect.Source {
+		case EffectSourceSpell:
+			if spell := FindSpellByID(effect.EffectID); spell != nil {
+				name = spell.Name
+			}
+		case EffectSourcePotion:
+			name = "Potion Effect"
+		case EffectSourcePoison:
+			name = "Poison"
+		case EffectSourceDisease:
+			name = "Disease"
+		case EffectSourceItem:
+			name = "Item Effect"
+		case EffectSourceScript:
+			name = "Scripted Effect"
+		}
+
+		remaining := time.Until(effect.ExpiresAt)
+		if remaining < 0 {
+			remaining = 0
+		}
+
+		msgs = append(msgs,
+			fmt.Sprintf(
+				"  %s: %s%d %s — %s remaining",
+				name,
+				modifierSign(effect.Modifier),
+				effect.Modifier,
+				statName(effect.Stat),
+				formatEffectDuration(remaining),
+			),
+		)
+
+		activeEffectCount++
+	}
+
+	if activeEffectCount == 0 {
+		msgs = append(msgs, "Active Effects: None")
+	}
+
 	return &CommandResult{Messages: msgs}
 }
 
+func modifierSign(modifier int) string {
+	if modifier >= 0 {
+		return "+"
+	}
+	return ""
+}
+
+func statName(stat StatID) string {
+	switch stat {
+	case StatStrength:
+		return "Strength"
+	case StatAgility:
+		return "Agility"
+	case StatQuickness:
+		return "Quickness"
+	case StatConstitution:
+		return "Constitution"
+	case StatPerception:
+		return "Perception"
+	case StatWillpower:
+		return "Willpower"
+	case StatEmpathy:
+		return "Empathy"
+	default:
+		return "Unknown Stat"
+	}
+}
+
+func formatEffectDuration(duration time.Duration) string {
+	duration = duration.Round(time.Second)
+
+	if duration >= time.Minute {
+		minutes := int(duration / time.Minute)
+		seconds := int(duration % time.Minute / time.Second)
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	}
+
+	return fmt.Sprintf("%ds", int(duration/time.Second))
+}
 func (e *GameEngine) doHealth(player *Player) *CommandResult {
 	healthPct := float64(player.BodyPoints) / float64(player.MaxBodyPoints) * 100
 	var healthDesc string
@@ -3232,7 +3444,10 @@ func (e *GameEngine) doWield(ctx context.Context, player *Player, args []string)
 		if !matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
 			continue
 		}
-		if skip > 0 { skip--; continue }
+		if skip > 0 {
+			skip--
+			continue
+		}
 		// Shields are worn, not wielded — route to WEAR
 		if itemDef.Type == "SHIELD" || (itemDef.WornSlot != "" && !isWeapon(itemDef.Type)) {
 			return e.doWear(ctx, player, args)
@@ -3291,7 +3506,10 @@ func (e *GameEngine) doWear(ctx context.Context, player *Player, args []string) 
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			worn := player.Inventory[i]
 			worn.WornSlot = itemDef.WornSlot
 			player.Inventory = append(player.Inventory[:i], player.Inventory[i+1:]...)
@@ -3321,7 +3539,10 @@ func (e *GameEngine) doRemove(ctx context.Context, player *Player, args []string
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			removed := player.Worn[i]
 			removed.WornSlot = ""
 			player.Worn = append(player.Worn[:i], player.Worn[i+1:]...)
@@ -3355,7 +3576,10 @@ func (e *GameEngine) doOpen(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			if !containsFlag(itemDef.Flags, "OPENABLE") && !isPortal(itemDef.Type) {
 				return &CommandResult{Messages: []string{"You can't open that."}}
 			}
@@ -3386,7 +3610,10 @@ func (e *GameEngine) doOpen(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			if !containsFlag(itemDef.Flags, "OPENABLE") {
 				return &CommandResult{Messages: []string{"You can't open that."}}
 			}
@@ -3417,12 +3644,16 @@ func (e *GameEngine) checkTrap(player *Player, ri *gameworld.RoomItem) []string 
 	case trapType == 3: // Acid
 		dmg := 10 + rand.Intn(15)
 		player.BodyPoints -= dmg
-		if player.BodyPoints < 0 { player.BodyPoints = 0 }
+		if player.BodyPoints < 0 {
+			player.BodyPoints = 0
+		}
 		msgs = append(msgs, fmt.Sprintf("Acid sprays out! [%d Damage]", dmg))
 	case trapType == 4: // Blades
 		dmg := 15 + rand.Intn(20)
 		player.BodyPoints -= dmg
-		if player.BodyPoints < 0 { player.BodyPoints = 0 }
+		if player.BodyPoints < 0 {
+			player.BodyPoints = 0
+		}
 		msgs = append(msgs, fmt.Sprintf("Hidden blades slash at you! [%d Damage]", dmg))
 	case trapType == 5: // Needle, moderate poison
 		msgs = append(msgs, "A poison-coated needle jabs into your hand!")
@@ -3433,12 +3664,16 @@ func (e *GameEngine) checkTrap(player *Player, ri *gameworld.RoomItem) []string 
 	case trapType == 8: // Explosive
 		dmg := 30 + rand.Intn(30)
 		player.BodyPoints -= dmg
-		if player.BodyPoints < 0 { player.BodyPoints = 0 }
+		if player.BodyPoints < 0 {
+			player.BodyPoints = 0
+		}
 		msgs = append(msgs, fmt.Sprintf("The container explodes! [%d Damage]", dmg))
 	case trapType == 9: // Acid, moderate
 		dmg := 20 + rand.Intn(25)
 		player.BodyPoints -= dmg
-		if player.BodyPoints < 0 { player.BodyPoints = 0 }
+		if player.BodyPoints < 0 {
+			player.BodyPoints = 0
+		}
 		msgs = append(msgs, fmt.Sprintf("A gout of acid sprays out! [%d Damage]", dmg))
 	case trapType == 12: // Gas, moderate poison
 		msgs = append(msgs, "A thick cloud of poisonous gas engulfs you!")
@@ -3446,13 +3681,17 @@ func (e *GameEngine) checkTrap(player *Player, ri *gameworld.RoomItem) []string 
 	case trapType == 13: // Black needle, lethal
 		dmg := 40 + rand.Intn(30)
 		player.BodyPoints -= dmg
-		if player.BodyPoints < 0 { player.BodyPoints = 0 }
+		if player.BodyPoints < 0 {
+			player.BodyPoints = 0
+		}
 		msgs = append(msgs, fmt.Sprintf("A black needle strikes you, delivering a lethal toxin! [%d Damage]", dmg))
 		player.Poisoned = true
 	case trapType >= 1000: // Glyph traps (spell-based)
 		spellDmg := 20 + rand.Intn(40)
 		player.BodyPoints -= spellDmg
-		if player.BodyPoints < 0 { player.BodyPoints = 0 }
+		if player.BodyPoints < 0 {
+			player.BodyPoints = 0
+		}
 		glyphType := (trapType / 1000) % 10
 		switch {
 		case glyphType <= 2:
@@ -3489,7 +3728,10 @@ func (e *GameEngine) doClose(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			room.Items[i].State = "CLOSED"
 			e.notifyRoomChange(RoomChange{RoomNumber: player.RoomNumber, Type: "item_state", ItemRef: ri.Ref, NewState: "CLOSED"})
 			fullName := e.formatItemName(itemDef, ri.Adj1, ri.Adj2, ri.Adj3)
@@ -3504,7 +3746,10 @@ func (e *GameEngine) doClose(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			player.Inventory[i].State = "CLOSED"
 			fullName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 			return &CommandResult{Messages: []string{fmt.Sprintf("You close %s.", fullName)}}
@@ -3676,7 +3921,6 @@ func (e *GameEngine) doChant(ctx context.Context, player *Player, args []string)
 		return &CommandResult{Messages: []string{"Chant what?"}}
 	}
 	target := strings.ToLower(strings.Join(args, " "))
-	// Strip "my " prefix
 	target = strings.TrimPrefix(target, "my ")
 	target, ordSkip := parseOrdinal(target)
 	skip := ordSkip
@@ -3690,24 +3934,43 @@ func (e *GameEngine) doChant(ctx context.Context, player *Player, args []string)
 			continue
 		}
 		name := e.getItemNounName(itemDef)
-		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 {
-				skip--
-				continue
-			}
-			fullName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
-			// Remove the scroll from inventory
-			player.Inventory = append(player.Inventory[:i], player.Inventory[i+1:]...)
-			player.RoundTimeExpiry = time.Now().Add(3 * time.Second)
-			e.SavePlayer(ctx, player)
-			return &CommandResult{
-				Messages: []string{
-					fmt.Sprintf("As you chant the scroll, it crumbles into dust..."),
-					"You feel the power of the scroll flow into you.",
-					"[Round: 3 sec]",
-				},
-				RoomBroadcast: []string{fmt.Sprintf("%s chants from %s which crumbles into dust.", player.FirstName, fullName)},
-			}
+		if !matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
+			continue
+		}
+		if skip > 0 {
+			skip--
+			continue
+		}
+
+		spellNum := ii.Val3
+		if spellNum == 0 {
+			return &CommandResult{Messages: []string{"This scroll holds no magical inscription."}}
+		}
+
+		spell := FindSpellByID(spellNum)
+		if spell == nil {
+			return &CommandResult{Messages: []string{"The scroll's magic is indecipherable."}}
+		}
+
+		fullName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
+
+		// Consume the scroll
+		player.Inventory = append(player.Inventory[:i], player.Inventory[i+1:]...)
+
+		// Prepare the spell — match the field name used by doPrepareSpell
+		player.PreparedSpell = spellNum // ← adjust field name to match your Player struct
+
+		player.RoundTimeExpiry = time.Now().Add(3 * time.Second)
+		e.SavePlayer(ctx, player)
+		return &CommandResult{
+			Messages: []string{
+				fmt.Sprintf("As you chant %s, it crumbles into dust...", fullName),
+				fmt.Sprintf("The power of %s flows into you. The spell is prepared.", spell.Name),
+				"[Round: 3 sec]",
+			},
+			RoomBroadcast: []string{
+				fmt.Sprintf("%s chants from %s which crumbles into dust.", player.FirstName, fullName),
+			},
 		}
 	}
 	return &CommandResult{Messages: []string{"You don't have that."}}
@@ -3898,7 +4161,10 @@ func (e *GameEngine) doGive(ctx context.Context, player *Player, args []string) 
 		if !matchesTarget(name, itemName, e.getAdjName(ii.Adj1)) {
 			continue
 		}
-		if skip > 0 { skip--; continue }
+		if skip > 0 {
+			skip--
+			continue
+		}
 		// Find the target player
 		target := e.findPlayerInRoom(player, targetName)
 		if target == nil {
@@ -3968,7 +4234,9 @@ func (e *GameEngine) doGiveMoney(ctx context.Context, giver, receiver *Player, a
 		giver.Gold -= amount
 		receiver.Gold += amount
 		currencyDisplay = fmt.Sprintf("%d gold crown", amount)
-		if amount != 1 { currencyDisplay += "s" }
+		if amount != 1 {
+			currencyDisplay += "s"
+		}
 	case "silver":
 		if giver.Silver < amount {
 			return &CommandResult{Messages: []string{fmt.Sprintf("You only have %d silver.", giver.Silver)}}
@@ -3976,7 +4244,9 @@ func (e *GameEngine) doGiveMoney(ctx context.Context, giver, receiver *Player, a
 		giver.Silver -= amount
 		receiver.Silver += amount
 		currencyDisplay = fmt.Sprintf("%d silver shilling", amount)
-		if amount != 1 { currencyDisplay += "s" }
+		if amount != 1 {
+			currencyDisplay += "s"
+		}
 	case "copper":
 		if giver.Copper < amount {
 			return &CommandResult{Messages: []string{fmt.Sprintf("You only have %d copper.", giver.Copper)}}
@@ -3984,7 +4254,11 @@ func (e *GameEngine) doGiveMoney(ctx context.Context, giver, receiver *Player, a
 		giver.Copper -= amount
 		receiver.Copper += amount
 		currencyDisplay = fmt.Sprintf("%d copper penn", amount)
-		if amount == 1 { currencyDisplay += "y" } else { currencyDisplay += "ies" }
+		if amount == 1 {
+			currencyDisplay += "y"
+		} else {
+			currencyDisplay += "ies"
+		}
 	default:
 		// Regional currencies — these are handled as inventory items with MONEY type
 		// Find the currency item in giver's inventory
@@ -4011,7 +4285,9 @@ func (e *GameEngine) doGiveMoney(ctx context.Context, giver, receiver *Player, a
 					receiver.Inventory = append(receiver.Inventory, newItem)
 				}
 				currencyDisplay = fmt.Sprintf("%d %s", amount, currency)
-				if amount != 1 { currencyDisplay += "s" }
+				if amount != 1 {
+					currencyDisplay += "s"
+				}
 				e.SavePlayer(ctx, giver)
 				e.SavePlayer(ctx, receiver)
 				return &CommandResult{
@@ -4052,7 +4328,10 @@ func (e *GameEngine) doEat(ctx context.Context, player *Player, args []string) *
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			fullName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 
 			// Run item scripts FIRST — they may set ITEMVAL3 based on adjective checks
@@ -4134,8 +4413,8 @@ func (e *GameEngine) doInfo(player *Player) *CommandResult {
 		fmt.Sprintf("Name: %s", player.FullName()),
 		fmt.Sprintf("Race: %s   Gender: %s   Level: %d", player.RaceName(), genderName(player.Gender), player.Level),
 		"",
-		fmt.Sprintf("Strength: %-3d   Agility: %-3d   Quickness: %d", player.Strength, player.Agility, player.Quickness),
-		fmt.Sprintf("Constitution: %-3d   Perception: %-3d   Willpower: %-3d   Empathy: %d", player.Constitution, player.Perception, player.Willpower, player.Empathy),
+		fmt.Sprintf("Strength: %-3d   Agility: %-3d   Quickness: %d", player.EffectiveStat(StatStrength), player.EffectiveStat(StatAgility), player.EffectiveStat(StatQuickness)),
+		fmt.Sprintf("Constitution: %-3d   Perception: %-3d   Willpower: %-3d   Empathy: %d", player.EffectiveStat(StatConstitution), player.EffectiveStat(StatPerception), player.EffectiveStat(StatWillpower), player.EffectiveStat(StatEmpathy)),
 		"",
 		fmt.Sprintf("Body Points: %d/%d   Fatigue: %d/%d", player.BodyPoints, player.MaxBodyPoints, player.Fatigue, player.MaxFatigue),
 		fmt.Sprintf("Mana: %d/%d   Psi: %d/%d", player.Mana, player.MaxMana, player.Psi, player.MaxPsi),
@@ -4169,7 +4448,10 @@ func (e *GameEngine) doBuy(ctx context.Context, player *Player, args []string) *
 		if !matchesTarget(name, target, adjName) {
 			continue
 		}
-		if skip > 0 { skip--; continue }
+		if skip > 0 {
+			skip--
+			continue
+		}
 
 		// Check affordability
 		totalCopper := player.Gold*100 + player.Silver*10 + player.Copper
@@ -4255,7 +4537,10 @@ func (e *GameEngine) doSell(ctx context.Context, player *Player, args []string) 
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			displayName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 			// Sell value: VAL1 on item is copper value, fallback to weight-based estimate
 			sellValue := ii.Val1
@@ -4264,7 +4549,9 @@ func (e *GameEngine) doSell(ctx context.Context, player *Player, args []string) 
 			}
 			// Merchants pay ~50% of value
 			sellValue = sellValue / 2
-			if sellValue < 1 { sellValue = 1 }
+			if sellValue < 1 {
+				sellValue = 1
+			}
 			player.Inventory = append(player.Inventory[:i], player.Inventory[i+1:]...)
 			// Add coins
 			player.Gold += sellValue / 100
@@ -4309,14 +4596,19 @@ func (e *GameEngine) doAppraise(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			displayName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 			sellValue := ii.Val1
 			if sellValue <= 0 {
 				sellValue = itemDef.Weight + 1
 			}
 			sellValue = sellValue / 2
-			if sellValue < 1 { sellValue = 1 }
+			if sellValue < 1 {
+				sellValue = 1
+			}
 			return &CommandResult{Messages: []string{
 				fmt.Sprintf("The merchant examines %s carefully.", displayName),
 				fmt.Sprintf("\"I'd give you %s for that.\"", formatPrice(sellValue)),
@@ -4376,7 +4668,10 @@ func (e *GameEngine) doDrink(ctx context.Context, player *Player, args []string)
 		if !matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
 			continue
 		}
-		if skip > 0 { skip--; continue }
+		if skip > 0 {
+			skip--
+			continue
+		}
 		displayName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 		if itemDef.Type == "FOOD" {
 			// EAT logic — redirect to doEat
@@ -4433,7 +4728,9 @@ func (e *GameEngine) doDrink(ctx context.Context, player *Player, args []string)
 
 func (e *GameEngine) doLight(ctx context.Context, player *Player, args []string, lightOn bool) *CommandResult {
 	if len(args) == 0 {
-		if lightOn { return &CommandResult{Messages: []string{"Light what?"}} }
+		if lightOn {
+			return &CommandResult{Messages: []string{"Light what?"}}
+		}
 		return &CommandResult{Messages: []string{"Extinguish what?"}}
 	}
 	target := strings.ToLower(strings.Join(args, " "))
@@ -4441,11 +4738,20 @@ func (e *GameEngine) doLight(ctx context.Context, player *Player, args []string,
 	skip := ordSkip
 	for i, ii := range player.Inventory {
 		itemDef := e.items[ii.Archetype]
-		if itemDef == nil { continue }
-		if !containsFlag(itemDef.Flags, "LIGHTABLE") { continue }
+		if itemDef == nil {
+			continue
+		}
+		if !containsFlag(itemDef.Flags, "LIGHTABLE") {
+			continue
+		}
 		name := e.getItemNounName(itemDef)
-		if !matchesTarget(name, target, e.getAdjName(ii.Adj1)) { continue }
-		if skip > 0 { skip--; continue }
+		if !matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
+			continue
+		}
+		if skip > 0 {
+			skip--
+			continue
+		}
 		displayName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
 		if lightOn {
 			player.Inventory[i].State = "LIT"
@@ -4460,19 +4766,32 @@ func (e *GameEngine) doLight(ctx context.Context, player *Player, args []string,
 }
 
 func (e *GameEngine) doFlip(ctx context.Context, player *Player, args []string) *CommandResult {
-	if len(args) == 0 { return &CommandResult{Messages: []string{"Flip what?"}} }
+	if len(args) == 0 {
+		return &CommandResult{Messages: []string{"Flip what?"}}
+	}
 	target := strings.ToLower(strings.Join(args, " "))
 	target, ordSkip := parseOrdinal(target)
 	skip := ordSkip
 	room := e.rooms[player.RoomNumber]
-	if room == nil { return &CommandResult{Messages: []string{"You can't do that here."}} }
+	if room == nil {
+		return &CommandResult{Messages: []string{"You can't do that here."}}
+	}
 	for i, ri := range room.Items {
 		itemDef := e.items[ri.Archetype]
-		if itemDef == nil { continue }
-		if !containsFlag(itemDef.Flags, "FLIPABLE") { continue }
+		if itemDef == nil {
+			continue
+		}
+		if !containsFlag(itemDef.Flags, "FLIPABLE") {
+			continue
+		}
 		name := e.getItemNounName(itemDef)
-		if !matchesTarget(name, target, e.getAdjName(ri.Adj1)) { continue }
-		if skip > 0 { skip--; continue }
+		if !matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
+			continue
+		}
+		if skip > 0 {
+			skip--
+			continue
+		}
 		displayName := e.formatItemName(itemDef, ri.Adj1, ri.Adj2, ri.Adj3)
 		if ri.State == "FLIPPED" {
 			room.Items[i].State = "UNFLIPPED"
@@ -4493,21 +4812,34 @@ func (e *GameEngine) doFlip(ctx context.Context, player *Player, args []string) 
 
 func (e *GameEngine) doLatch(player *Player, args []string, latch bool) *CommandResult {
 	if len(args) == 0 {
-		if latch { return &CommandResult{Messages: []string{"Latch what?"}} }
+		if latch {
+			return &CommandResult{Messages: []string{"Latch what?"}}
+		}
 		return &CommandResult{Messages: []string{"Unlatch what?"}}
 	}
 	target := strings.ToLower(strings.Join(args, " "))
 	target, ordSkip := parseOrdinal(target)
 	skip := ordSkip
 	room := e.rooms[player.RoomNumber]
-	if room == nil { return &CommandResult{Messages: []string{"You can't do that here."}} }
+	if room == nil {
+		return &CommandResult{Messages: []string{"You can't do that here."}}
+	}
 	for i, ri := range room.Items {
 		itemDef := e.items[ri.Archetype]
-		if itemDef == nil { continue }
-		if !containsFlag(itemDef.Flags, "LATCHABLE") { continue }
+		if itemDef == nil {
+			continue
+		}
+		if !containsFlag(itemDef.Flags, "LATCHABLE") {
+			continue
+		}
 		name := e.getItemNounName(itemDef)
-		if !matchesTarget(name, target, e.getAdjName(ri.Adj1)) { continue }
-		if skip > 0 { skip--; continue }
+		if !matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
+			continue
+		}
+		if skip > 0 {
+			skip--
+			continue
+		}
 		displayName := e.formatItemName(itemDef, ri.Adj1, ri.Adj2, ri.Adj3)
 		if latch {
 			room.Items[i].State = "LATCHED"
@@ -4670,19 +5002,43 @@ func (e *GameEngine) doDeposit(ctx context.Context, player *Player, args []strin
 	if room == nil || !containsModifier(room.Modifiers, "BANK") {
 		return &CommandResult{Messages: []string{"There is no bank here."}}
 	}
-	if len(args) == 0 { return &CommandResult{Messages: []string{"Deposit how much?"}} }
+	if len(args) == 0 {
+		return &CommandResult{Messages: []string{"Deposit how much?"}}
+	}
 	amount := 0
 	fmt.Sscanf(args[0], "%d", &amount)
-	if amount <= 0 { return &CommandResult{Messages: []string{"Invalid amount."}} }
+	if amount <= 0 {
+		return &CommandResult{Messages: []string{"Invalid amount."}}
+	}
 	totalCopper := player.Gold*100 + player.Silver*10 + player.Copper
 	if totalCopper < amount {
 		return &CommandResult{Messages: []string{"You don't have that much money."}}
 	}
 	// Deduct from carried
 	remaining := amount
-	if player.Copper >= remaining { player.Copper -= remaining; remaining = 0 } else { remaining -= player.Copper; player.Copper = 0 }
-	if remaining > 0 { sn := (remaining+9)/10; if player.Silver >= sn { player.Silver -= sn; player.Copper += sn*10-remaining; remaining = 0 } else { remaining -= player.Silver*10; player.Silver = 0 } }
-	if remaining > 0 { gn := (remaining+99)/100; player.Gold -= gn; player.Copper += gn*100-remaining }
+	if player.Copper >= remaining {
+		player.Copper -= remaining
+		remaining = 0
+	} else {
+		remaining -= player.Copper
+		player.Copper = 0
+	}
+	if remaining > 0 {
+		sn := (remaining + 9) / 10
+		if player.Silver >= sn {
+			player.Silver -= sn
+			player.Copper += sn*10 - remaining
+			remaining = 0
+		} else {
+			remaining -= player.Silver * 10
+			player.Silver = 0
+		}
+	}
+	if remaining > 0 {
+		gn := (remaining + 99) / 100
+		player.Gold -= gn
+		player.Copper += gn*100 - remaining
+	}
 	player.BankCopper += amount
 	e.SavePlayer(ctx, player)
 	return &CommandResult{Messages: []string{fmt.Sprintf("You deposit %s.", formatPrice(amount))}}
@@ -4693,25 +5049,53 @@ func (e *GameEngine) doWithdraw(ctx context.Context, player *Player, args []stri
 	if room == nil || !containsModifier(room.Modifiers, "BANK") {
 		return &CommandResult{Messages: []string{"There is no bank here."}}
 	}
-	if len(args) == 0 { return &CommandResult{Messages: []string{"Withdraw how much?"}} }
+	if len(args) == 0 {
+		return &CommandResult{Messages: []string{"Withdraw how much?"}}
+	}
 	amount := 0
 	fmt.Sscanf(args[0], "%d", &amount)
-	if amount <= 0 { return &CommandResult{Messages: []string{"Invalid amount."}} }
+	if amount <= 0 {
+		return &CommandResult{Messages: []string{"Invalid amount."}}
+	}
 	totalBank := player.BankGold*100 + player.BankSilver*10 + player.BankCopper
 	if totalBank < amount {
 		return &CommandResult{Messages: []string{"You don't have that much in the bank."}}
 	}
 	remaining := amount
-	if player.BankCopper >= remaining { player.BankCopper -= remaining; remaining = 0 } else { remaining -= player.BankCopper; player.BankCopper = 0 }
-	if remaining > 0 { sn := (remaining+9)/10; if player.BankSilver >= sn { player.BankSilver -= sn; player.BankCopper += sn*10-remaining; remaining = 0 } else { remaining -= player.BankSilver*10; player.BankSilver = 0 } }
-	if remaining > 0 { gn := (remaining+99)/100; player.BankGold -= gn; player.BankCopper += gn*100-remaining }
+	if player.BankCopper >= remaining {
+		player.BankCopper -= remaining
+		remaining = 0
+	} else {
+		remaining -= player.BankCopper
+		player.BankCopper = 0
+	}
+	if remaining > 0 {
+		sn := (remaining + 9) / 10
+		if player.BankSilver >= sn {
+			player.BankSilver -= sn
+			player.BankCopper += sn*10 - remaining
+			remaining = 0
+		} else {
+			remaining -= player.BankSilver * 10
+			player.BankSilver = 0
+		}
+	}
+	if remaining > 0 {
+		gn := (remaining + 99) / 100
+		player.BankGold -= gn
+		player.BankCopper += gn*100 - remaining
+	}
 	player.Copper += amount
 	e.SavePlayer(ctx, player)
 	return &CommandResult{Messages: []string{fmt.Sprintf("You withdraw %s.", formatPrice(amount))}}
 }
 
 func containsModifier(mods []string, mod string) bool {
-	for _, m := range mods { if m == mod { return true } }
+	for _, m := range mods {
+		if m == mod {
+			return true
+		}
+	}
 	return false
 }
 
@@ -4793,8 +5177,10 @@ func (e *GameEngine) doHide(ctx context.Context, player *Player) *CommandResult 
 	}
 	// Stealth skill check: base 25% + stealth*5 + AGI/10
 	stealthSkill := player.Skills[33]
-	hideChance := 25 + stealthSkill*5 + player.Agility/10
-	if hideChance > 95 { hideChance = 95 }
+	hideChance := 25 + stealthSkill*5 + player.EffectiveStat(StatAgility)/10
+	if hideChance > 95 {
+		hideChance = 95
+	}
 	if rand.Intn(100) >= hideChance {
 		return &CommandResult{
 			Messages:      []string{"You fail to find a suitable hiding place."},
@@ -4829,8 +5215,10 @@ func (e *GameEngine) doSneak(ctx context.Context, player *Player, args []string)
 	}
 	// Stealth check to stay hidden while moving
 	stealthSkill := player.Skills[33]
-	sneakChance := 30 + stealthSkill*5 + player.Agility/10
-	if sneakChance > 90 { sneakChance = 90 }
+	sneakChance := 30 + stealthSkill*5 + player.EffectiveStat(StatAgility)/10
+	if sneakChance > 90 {
+		sneakChance = 90
+	}
 	result := e.doMove(ctx, player, dir)
 	if rand.Intn(100) >= sneakChance {
 		player.Hidden = false
@@ -4874,10 +5262,10 @@ func (e *GameEngine) doMark(ctx context.Context, player *Player, args []string) 
 					name = r.Name
 				}
 				if player.IsGM {
-				msgs = append(msgs, fmt.Sprintf("  Mark %d: %s (%d)", i, name, roomNum))
-			} else {
-				msgs = append(msgs, fmt.Sprintf("  Mark %d: %s", i, name))
-			}
+					msgs = append(msgs, fmt.Sprintf("  Mark %d: %s (%d)", i, name, roomNum))
+				} else {
+					msgs = append(msgs, fmt.Sprintf("  Mark %d: %s", i, name))
+				}
 			}
 		}
 		return &CommandResult{Messages: msgs}
@@ -4999,7 +5387,10 @@ func (e *GameEngine) doRead(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ri.Adj1)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			return e.readRoomItem(room, itemDef, &ri)
 		}
 	}
@@ -5008,7 +5399,9 @@ func (e *GameEngine) doRead(player *Player, args []string) *CommandResult {
 	allReadItems := make([]InventoryItem, 0, len(player.Inventory)+len(player.Worn)+1)
 	allReadItems = append(allReadItems, player.Inventory...)
 	allReadItems = append(allReadItems, player.Worn...)
-	if player.Wielded != nil { allReadItems = append(allReadItems, *player.Wielded) }
+	if player.Wielded != nil {
+		allReadItems = append(allReadItems, *player.Wielded)
+	}
 	for _, ii := range allReadItems {
 		itemDef := e.items[ii.Archetype]
 		if itemDef == nil {
@@ -5016,7 +5409,10 @@ func (e *GameEngine) doRead(player *Player, args []string) *CommandResult {
 		}
 		name := e.getItemNounName(itemDef)
 		if matchesTarget(name, target, e.getAdjName(ii.Adj1)) || matchesTarget(name, target, e.getAdjName(ii.Adj3)) {
-			if skip > 0 { skip--; continue }
+			if skip > 0 {
+				skip--
+				continue
+			}
 			return &CommandResult{Messages: []string{"There is nothing written on it."}}
 		}
 	}
@@ -5105,14 +5501,14 @@ func (e *GameEngine) CreateNewPlayer(ctx context.Context, firstName, lastName st
 	// Race-based height/weight ranges: [minHeight, maxHeight, minWeight, maxWeight]
 	// Heights in inches, weights in lbs. Based on original GM manual.
 	heightWeightRanges := map[int][4]int{
-		1: {62, 76, 120, 220},  // Human
-		2: {66, 80, 100, 170},  // Aelfen (tall, slender)
-		3: {48, 58, 130, 200},  // Highlander (short, rugged)
-		4: {64, 74, 130, 200},  // Wolfling
-		5: {62, 74, 150, 230},  // Murg (burly)
-		6: {68, 82, 150, 250},  // Drakin (large)
-		7: {60, 74, 150, 250},  // Mechanoid
-		8: {58, 72, 80, 130},   // Ephemeral (wispy)
+		1: {62, 76, 120, 220}, // Human
+		2: {66, 80, 100, 170}, // Aelfen (tall, slender)
+		3: {48, 58, 130, 200}, // Highlander (short, rugged)
+		4: {64, 74, 130, 200}, // Wolfling
+		5: {62, 74, 150, 230}, // Murg (burly)
+		6: {68, 82, 150, 250}, // Drakin (large)
+		7: {60, 74, 150, 250}, // Mechanoid
+		8: {58, 72, 80, 130},  // Ephemeral (wispy)
 	}
 	hw := heightWeightRanges[race]
 	if hw == [4]int{} {
@@ -5124,49 +5520,53 @@ func (e *GameEngine) CreateNewPlayer(ctx context.Context, firstName, lastName st
 	if gender == 1 {
 		height -= 2 + rand.Intn(3)
 		weight -= 10 + rand.Intn(20)
-		if height < hw[0]-4 { height = hw[0] - 4 }
-		if weight < hw[2]-20 { weight = hw[2] - 20 }
+		if height < hw[0]-4 {
+			height = hw[0] - 4
+		}
+		if weight < hw[2]-20 {
+			weight = hw[2] - 20
+		}
 	}
 
 	now := time.Now()
 	player := &Player{
-		FirstName:     firstName,
-		LastName:      lastName,
-		Race:          race,
-		Gender:        gender,
-		Level:         1,
-		BuildPoints:   30, // 30 starting build points for initial skills
-		Strength:      str,
-		Agility:       agi,
-		Quickness:     qui,
-		Constitution:  con,
-		Perception:    per,
-		Willpower:     wil,
-		Empathy:       emp,
-		BodyPoints:    bodyPts,
-		MaxBodyPoints: bodyPts,
-		Fatigue:       fatigue,
-		MaxFatigue:    fatigue,
-		Mana:          mana,
-		MaxMana:       mana,
-		Psi:           psi,
-		MaxPsi:        psi,
-		Height:        height,
-		HeightTrue:    height,
-		Weight:        weight,
-		WeightTrue:    weight,
-		RoomNumber:    201, // Start at City Gate (tutorial room 3950 requires script execution)
-		Position:      0,
-		Skills:        make(map[int]int),
-		IntNums:       make(map[int]int),
-		Gold:          5,
-		Silver:        10,
-		Copper:        50,
-		PromptMode:       true,
-		SuppressLogon:    true, // login/logout messages off by default for new characters
-		SuppressLogoff:   true,
-		CreatedAt:        now,
-		UpdatedAt:        now,
+		FirstName:      firstName,
+		LastName:       lastName,
+		Race:           race,
+		Gender:         gender,
+		Level:          1,
+		BuildPoints:    30, // 30 starting build points for initial skills
+		Strength:       str,
+		Agility:        agi,
+		Quickness:      qui,
+		Constitution:   con,
+		Perception:     per,
+		Willpower:      wil,
+		Empathy:        emp,
+		BodyPoints:     bodyPts,
+		MaxBodyPoints:  bodyPts,
+		Fatigue:        fatigue,
+		MaxFatigue:     fatigue,
+		Mana:           mana,
+		MaxMana:        mana,
+		Psi:            psi,
+		MaxPsi:         psi,
+		Height:         height,
+		HeightTrue:     height,
+		Weight:         weight,
+		WeightTrue:     weight,
+		RoomNumber:     201, // Start at City Gate (tutorial room 3950 requires script execution)
+		Position:       0,
+		Skills:         make(map[int]int),
+		IntNums:        make(map[int]int),
+		Gold:           5,
+		Silver:         10,
+		Copper:         50,
+		PromptMode:     true,
+		SuppressLogon:  true, // login/logout messages off by default for new characters
+		SuppressLogoff: true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 	if race == RaceEphemeral {
 		player.TelepathyActive = true
@@ -5427,7 +5827,12 @@ func (e *GameEngine) doSet(ctx context.Context, player *Player, args []string) *
 		}
 		lines := []string{
 			"Current Settings:",
-			fmt.Sprintf("  Full:                %s", func() string { if player.BriefMode { return "OFF" }; return "ON" }()),
+			fmt.Sprintf("  Full:                %s", func() string {
+				if player.BriefMode {
+					return "OFF"
+				}
+				return "ON"
+			}()),
 			fmt.Sprintf("  Brief:               %s", briefMode),
 			fmt.Sprintf("  Prompt:              %s", promptMode),
 			fmt.Sprintf("  Logon messages:      %s", onOff(player.SuppressLogon)),
@@ -5522,13 +5927,19 @@ func (e *GameEngine) SavePlayer(ctx context.Context, player *Player) {
 func (e *GameEngine) formatItemNameNoArticle(def *gameworld.ItemDef, adj1, adj2, adj3 int) string {
 	var parts []string
 	if adj1 > 0 {
-		if name, ok := e.adjectives[adj1]; ok { parts = append(parts, name) }
+		if name, ok := e.adjectives[adj1]; ok {
+			parts = append(parts, name)
+		}
 	}
 	if adj2 > 0 {
-		if name, ok := e.adjectives[adj2]; ok { parts = append(parts, name) }
+		if name, ok := e.adjectives[adj2]; ok {
+			parts = append(parts, name)
+		}
 	}
 	if adj3 > 0 {
-		if name, ok := e.adjectives[adj3]; ok { parts = append(parts, name) }
+		if name, ok := e.adjectives[adj3]; ok {
+			parts = append(parts, name)
+		}
 	}
 	parts = append(parts, e.getItemNounName(def))
 	return strings.Join(parts, " ")
@@ -5869,8 +6280,8 @@ func (e *GameEngine) GenerateAPIKey(ctx context.Context, firstName, accountID st
 	filter := bson.M{"firstName": firstName, "accountId": accountID, "deletedAt": bson.M{"$exists": false}}
 	update := bson.M{"$set": bson.M{
 		"apiKeyHash":   hashStr,
-		"apiKeyPrefix":  prefix,
-		"botGMAllowed":  allowGM,
+		"apiKeyPrefix": prefix,
+		"botGMAllowed": allowGM,
 	}}
 	result, err := coll.UpdateOne(ctx, filter, update)
 	if err != nil {
@@ -5913,7 +6324,9 @@ func (e *GameEngine) ValidateAPIKey(ctx context.Context, key string) (*Player, e
 }
 
 func isSelfOr(isSelf bool, selfText, otherText string) string {
-	if isSelf { return selfText }
+	if isSelf {
+		return selfText
+	}
 	return otherText
 }
 

--- a/engine/internal/engine/player.go
+++ b/engine/internal/engine/player.go
@@ -36,6 +36,32 @@ var RaceStatRanges = map[int][7][2]int{
 	RaceWolfling:   {{30, 100}, {40, 110}, {40, 110}, {30, 100}, {40, 110}, {30, 100}, {30, 100}},
 }
 
+type StatID int
+
+const (
+	StatStrength StatID = iota
+	StatAgility
+	StatQuickness
+	StatConstitution
+	StatPerception
+	StatWillpower
+	StatEmpathy
+	HasteBuff
+	SlowDebuff
+)
+
+type EffectSource int
+
+const (
+	EffectSourceSpell EffectSource = iota
+	EffectSourcePotion
+	EffectSourcePoison
+	EffectSourceDisease
+	EffectSourceItem
+	EffectSourceGM
+	EffectSourceScript
+)
+
 // Gender constants
 const (
 	GenderMale   = 0
@@ -44,14 +70,14 @@ const (
 
 // Player represents a player's current state.
 type Player struct {
-	ID         bson.ObjectID     `bson:"_id,omitempty" json:"id"`
-	AccountID  string            `bson:"accountId,omitempty" json:"accountId,omitempty"`
-	FirstName  string            `bson:"firstName" json:"firstName"`
-	LastName   string            `bson:"lastName" json:"lastName"`
-	Race       int               `bson:"race" json:"race"`
-	Gender     int               `bson:"gender" json:"gender"`
-	Level      int               `bson:"level" json:"level"`
-	Experience int               `bson:"experience" json:"experience"`
+	ID         bson.ObjectID `bson:"_id,omitempty" json:"id"`
+	AccountID  string        `bson:"accountId,omitempty" json:"accountId,omitempty"`
+	FirstName  string        `bson:"firstName" json:"firstName"`
+	LastName   string        `bson:"lastName" json:"lastName"`
+	Race       int           `bson:"race" json:"race"`
+	Gender     int           `bson:"gender" json:"gender"`
+	Level      int           `bson:"level" json:"level"`
+	Experience int           `bson:"experience" json:"experience"`
 
 	// Stats
 	Strength     int `bson:"strength" json:"strength"`
@@ -74,33 +100,33 @@ type Player struct {
 
 	// Position
 	RoomNumber int  `bson:"roomNumber" json:"roomNumber"`
-	Position   int  `bson:"position" json:"position"` // 0=standing, 1=sitting, 2=laying, 3=kneeling, 4=flying
-	Hidden     bool `bson:"hidden" json:"hidden"`         // stealth: revealed by movement, emotes, attacks
-	Invisible  bool `bson:"invisible" json:"invisible"`   // spell effect: not revealed by movement, only by attacks or dispel
+	Position   int  `bson:"position" json:"position"`   // 0=standing, 1=sitting, 2=laying, 3=kneeling, 4=flying
+	Hidden     bool `bson:"hidden" json:"hidden"`       // stealth: revealed by movement, emotes, attacks
+	Invisible  bool `bson:"invisible" json:"invisible"` // spell effect: not revealed by movement, only by attacks or dispel
 	Dead       bool `bson:"dead" json:"dead"`
 
 	// Physical attributes
-	Height     int `bson:"height,omitempty" json:"height,omitempty"`       // inches
+	Height     int `bson:"height,omitempty" json:"height,omitempty"` // inches
 	HeightTrue int `bson:"heightTrue,omitempty" json:"heightTrue,omitempty"`
-	Weight     int `bson:"weight,omitempty" json:"weight,omitempty"`       // pounds (base, not inventory)
+	Weight     int `bson:"weight,omitempty" json:"weight,omitempty"` // pounds (base, not inventory)
 	WeightTrue int `bson:"weightTrue,omitempty" json:"weightTrue,omitempty"`
 	Age        int `bson:"age,omitempty" json:"age,omitempty"`
 	AgeTrue    int `bson:"ageTrue,omitempty" json:"ageTrue,omitempty"`
 
 	// Status conditions
-	Bleeding    bool `bson:"bleeding" json:"bleeding"`
-	Stunned     bool `bson:"stunned" json:"stunned"`
-	Diseased    bool `bson:"diseased" json:"diseased"`
-	Poisoned    bool `bson:"poisoned" json:"poisoned"`
-	Joined      bool `bson:"joined" json:"joined"`
-	Unconscious bool `bson:"unconscious" json:"unconscious"`
-	Immobilized bool `bson:"immobilized" json:"immobilized"`
-	Sleeping    bool `bson:"sleeping,omitempty" json:"sleeping,omitempty"`
-	Submitting  bool `bson:"submitting,omitempty" json:"submitting,omitempty"`
-	Undead      bool `bson:"undead,omitempty" json:"undead,omitempty"`
-	WolfForm    bool `bson:"wolfForm,omitempty" json:"wolfForm,omitempty"`
-	SlimeForm   bool `bson:"slimeForm,omitempty" json:"slimeForm,omitempty"`
-	Disguised   bool `bson:"disguised,omitempty" json:"disguised,omitempty"`
+	Bleeding        bool      `bson:"bleeding" json:"bleeding"`
+	Stunned         bool      `bson:"stunned" json:"stunned"`
+	Diseased        bool      `bson:"diseased" json:"diseased"`
+	Poisoned        bool      `bson:"poisoned" json:"poisoned"`
+	Joined          bool      `bson:"joined" json:"joined"`
+	Unconscious     bool      `bson:"unconscious" json:"unconscious"`
+	Immobilized     bool      `bson:"immobilized" json:"immobilized"`
+	Sleeping        bool      `bson:"sleeping,omitempty" json:"sleeping,omitempty"`
+	Submitting      bool      `bson:"submitting,omitempty" json:"submitting,omitempty"`
+	Undead          bool      `bson:"undead,omitempty" json:"undead,omitempty"`
+	WolfForm        bool      `bson:"wolfForm,omitempty" json:"wolfForm,omitempty"`
+	SlimeForm       bool      `bson:"slimeForm,omitempty" json:"slimeForm,omitempty"`
+	Disguised       bool      `bson:"disguised,omitempty" json:"disguised,omitempty"`
 	RoundTime       int       `bson:"roundTime" json:"roundTime"`
 	RoundTimeExpiry time.Time `bson:"-" json:"-"` // transient: when roundtime ends
 	CanFly          bool      `bson:"canFly" json:"canFly"`
@@ -108,20 +134,23 @@ type Player struct {
 	PreparedSpell   int       `bson:"preparedSpell,omitempty" json:"preparedSpell,omitempty"`
 
 	// Combat
-	Stance        int           `bson:"-" json:"-"`          // StanceNormal..StanceBerserk
-	CombatTarget  *CombatTarget `bson:"-" json:"-"`          // current combat target
-	DefenseBonus  int           `bson:"-" json:"-"`          // from spells/psi
-	PreparedPsi   int           `bson:"-" json:"-"`          // prepared psi discipline ID
-	ActivePsi     map[int]bool `bson:"-" json:"-"`          // currently maintained psi disciplines
-	BackstabNext  bool          `bson:"-" json:"-"`          // next attack is a backstab
-	TelepathyActive bool      `bson:"telepathyActive,omitempty" json:"telepathyActive,omitempty"`
-	TelepathyExpiry time.Time `bson:"telepathyExpiry,omitempty" json:"telepathyExpiry,omitempty"`
-	Emotional       bool      `bson:"emotional,omitempty" json:"emotional,omitempty"`
+	Stance          int           `bson:"-" json:"-"` // StanceNormal..StanceBerserk
+	CombatTarget    *CombatTarget `bson:"-" json:"-"` // current combat target
+	DefenseBonus    int           `bson:"-" json:"-"` // from spells/psi
+	PreparedPsi     int           `bson:"-" json:"-"` // prepared psi discipline ID
+	ActivePsi       map[int]bool  `bson:"-" json:"-"` // currently maintained psi disciplines
+	BackstabNext    bool          `bson:"-" json:"-"` // next attack is a backstab
+	TelepathyActive bool          `bson:"telepathyActive,omitempty" json:"telepathyActive,omitempty"`
+	TelepathyExpiry time.Time     `bson:"telepathyExpiry,omitempty" json:"telepathyExpiry,omitempty"`
+	Emotional       bool          `bson:"emotional,omitempty" json:"emotional,omitempty"`
+
+	// Temporary spell/stat modifiers
+	ActiveStatEffects []StatEffect `bson:"activeStatEffects,omitempty" json:"activeStatEffects,omitempty"`
 
 	// Crafting state (transient)
-	CraftingItem string `bson:"-" json:"-"` // what they're making (e.g., "greatsword")
+	CraftingItem  string `bson:"-" json:"-"` // what they're making (e.g., "greatsword")
 	CraftingMetal string `bson:"-" json:"-"` // what material (e.g., "copper")
-	CraftingStep int    `bson:"-" json:"-"` // 0=not crafting, 1=planned, 2=heated, 3=hammered, 4=quenched, 5=buffed, 6=done
+	CraftingStep  int    `bson:"-" json:"-"` // 0=not crafting, 1=planned, 2=heated, 3=hammered, 4=quenched, 5=buffed, 6=done
 
 	// Teaching: skill being taught to others (transient)
 	Teaching      int `bson:"-" json:"-"` // skill number being taught (0 = not teaching)
@@ -161,7 +190,7 @@ type Player struct {
 	BuildPoints  int `bson:"buildPoints,omitempty" json:"buildPoints,omitempty"`
 
 	// Skills
-	Skills      map[int]int  `bson:"skills" json:"skills"`           // skill# -> level
+	Skills      map[int]int  `bson:"skills" json:"skills"`                               // skill# -> level
 	KnownSpells map[int]bool `bson:"knownSpells,omitempty" json:"knownSpells,omitempty"` // spell# -> known
 
 	// Internal variables (INTNUM0-99, flags, etc.)
@@ -174,17 +203,17 @@ type Player struct {
 	Flag4 int `bson:"-" json:"-"`
 
 	// Appearance / Description
-	DescLine1  string `bson:"descLine1,omitempty" json:"descLine1,omitempty"` // custom description lines (visible on EXAMINE)
-	DescLine2  string `bson:"descLine2,omitempty" json:"descLine2,omitempty"`
-	DescLine3  string `bson:"descLine3,omitempty" json:"descLine3,omitempty"`
-	EntryEcho  string `bson:"entryEcho,omitempty" json:"entryEcho,omitempty"` // custom room entry text (replaces "X arrives.")
-	ExitEcho   string `bson:"exitEcho,omitempty" json:"exitEcho,omitempty"`   // custom room exit text (replaces "X goes north.")
+	DescLine1 string `bson:"descLine1,omitempty" json:"descLine1,omitempty"` // custom description lines (visible on EXAMINE)
+	DescLine2 string `bson:"descLine2,omitempty" json:"descLine2,omitempty"`
+	DescLine3 string `bson:"descLine3,omitempty" json:"descLine3,omitempty"`
+	EntryEcho string `bson:"entryEcho,omitempty" json:"entryEcho,omitempty"` // custom room entry text (replaces "X arrives.")
+	ExitEcho  string `bson:"exitEcho,omitempty" json:"exitEcho,omitempty"`   // custom room exit text (replaces "X goes north.")
 
 	// Bot / API Key
-	APIKeyHash    string `bson:"apiKeyHash,omitempty" json:"-"`                       // bcrypt hash of API key (never sent to client)
-	APIKeyPrefix  string `bson:"apiKeyPrefix,omitempty" json:"apiKeyPrefix,omitempty"` // first 8 chars for display
-	BotGMAllowed  bool   `bson:"botGMAllowed,omitempty" json:"botGMAllowed,omitempty"` // whether bot can use GM commands
-	IsBot         bool   `bson:"-" json:"-"`                                           // transient: connected via API key
+	APIKeyHash   string `bson:"apiKeyHash,omitempty" json:"-"`                        // bcrypt hash of API key (never sent to client)
+	APIKeyPrefix string `bson:"apiKeyPrefix,omitempty" json:"apiKeyPrefix,omitempty"` // first 8 chars for display
+	BotGMAllowed bool   `bson:"botGMAllowed,omitempty" json:"botGMAllowed,omitempty"` // whether bot can use GM commands
+	IsBot        bool   `bson:"-" json:"-"`                                           // transient: connected via API key
 
 	// Settings (persistent toggles via SET command)
 	// Note: SuppressLogon/Logoff default to true for new characters (set in CreateNewPlayer).
@@ -201,11 +230,11 @@ type Player struct {
 	PromptMode   bool   `bson:"promptMode" json:"promptMode"`
 	SpeechAdverb string `bson:"speechAdverb,omitempty" json:"speechAdverb,omitempty"` // e.g. "gently"
 	IsGM         bool   `bson:"isGM" json:"isGM"`
-	GMTrace    bool `bson:"-" json:"-"`                                     // @trace: show script debug output
-	GMHat      bool `bson:"gmHat,omitempty" json:"gmHat,omitempty"`        // visible as GM on WHO list
-	GMHidden   bool `bson:"gmHidden,omitempty" json:"gmHidden,omitempty"`  // hidden from WHO list
-	GMInvis      bool   `bson:"gmInvis,omitempty" json:"gmInvis,omitempty"`    // invisible to players
-	GMEditTarget string `bson:"-" json:"-"` // @edpl target name for subsequent @set commands
+	GMTrace      bool   `bson:"-" json:"-"`                                   // @trace: show script debug output
+	GMHat        bool   `bson:"gmHat,omitempty" json:"gmHat,omitempty"`       // visible as GM on WHO list
+	GMHidden     bool   `bson:"gmHidden,omitempty" json:"gmHidden,omitempty"` // hidden from WHO list
+	GMInvis      bool   `bson:"gmInvis,omitempty" json:"gmInvis,omitempty"`   // invisible to players
+	GMEditTarget string `bson:"-" json:"-"`                                   // @edpl target name for subsequent @set commands
 
 	// Player title (e.g., "the Baroness") — shown on LOOK/EXAMINE
 	Title string `bson:"title,omitempty" json:"title,omitempty"`
@@ -228,6 +257,14 @@ type InventoryItem struct {
 	Val5      int    `bson:"val5,omitempty" json:"val5,omitempty"`
 	State     string `bson:"state,omitempty" json:"state,omitempty"`
 	WornSlot  string `bson:"wornSlot,omitempty" json:"wornSlot,omitempty"`
+}
+
+type StatEffect struct {
+	EffectID  int          `bson:"effectId" json:"effectId"` // Spell ID, Potion ID, etc.
+	Source    EffectSource `bson:"source" json:"source"`     // Spell, Potion, Item...
+	Stat      StatID       `bson:"stat" json:"stat"`
+	Modifier  int          `bson:"modifier" json:"modifier"`
+	ExpiresAt time.Time    `bson:"expiresAt" json:"expiresAt"`
 }
 
 // FullName returns the player's display name.
@@ -345,4 +382,70 @@ func RaceNameByID(race int) string {
 // IsFlying returns true if the player is able to fly (Drakin race or magical effect).
 func (p *Player) IsFlying() bool {
 	return p.Race == RaceDrakin || p.CanFly
+}
+
+func (p *Player) EffectiveStat(stat StatID) int {
+	now := time.Now()
+
+	var value int
+
+	switch stat {
+	case StatStrength:
+		value = p.Strength
+	case StatAgility:
+		value = p.Agility
+	case StatQuickness:
+		value = p.Quickness
+	case StatConstitution:
+		value = p.Constitution
+	case StatPerception:
+		value = p.Perception
+	case StatWillpower:
+		value = p.Willpower
+	case StatEmpathy:
+		value = p.Empathy
+	default:
+		return 0
+	}
+
+	for _, effect := range p.ActiveStatEffects {
+		if effect.Stat != stat {
+			continue
+		}
+
+		if effect.ExpiresAt.After(now) {
+			value += effect.Modifier
+		}
+	}
+
+	return value
+}
+
+func (p *Player) ApplyStatEffect(
+	effectID int,
+	source EffectSource,
+	stat StatID,
+	modifier int,
+	duration time.Duration,
+) {
+	expiresAt := time.Now().Add(duration)
+
+	for i := range p.ActiveStatEffects {
+		effect := &p.ActiveStatEffects[i]
+
+		if effect.EffectID == effectID && effect.Source == source {
+			effect.Stat = stat
+			effect.Modifier = modifier
+			effect.ExpiresAt = expiresAt
+			return
+		}
+	}
+
+	p.ActiveStatEffects = append(p.ActiveStatEffects, StatEffect{
+		EffectID:  effectID,
+		Source:    source,
+		Stat:      stat,
+		Modifier:  modifier,
+		ExpiresAt: expiresAt,
+	})
 }

--- a/engine/internal/engine/psionics.go
+++ b/engine/internal/engine/psionics.go
@@ -312,7 +312,7 @@ func (e *GameEngine) doProjectPsi(ctx context.Context, player *Player, args []st
 	} else {
 		schoolSkill = player.Skills[27]
 	}
-	castChance := 50 + (psiSkill+schoolSkill)*3 + player.Willpower/5 - disc.Level*2
+	castChance := 50 + (psiSkill+schoolSkill)*3 + player.EffectiveStat(StatWillpower)/5 - disc.Level*2
 	if castChance < 15 {
 		castChance = 15
 	}
@@ -556,7 +556,7 @@ func (e *GameEngine) projectManipulateLock(player *Player, args []string) *Comma
 		}
 		// Skill check: psi skill + willpower vs lock difficulty
 		psiSkill := player.Skills[26] + player.Skills[28]
-		chance := 40 + psiSkill*3 + player.Willpower/5
+		chance := 40 + psiSkill*3 + player.EffectiveStat(StatWillpower)/5
 		if player.IsGM {
 			chance = 100
 		}

--- a/engine/internal/engine/scripts.go
+++ b/engine/internal/engine/scripts.go
@@ -11,17 +11,17 @@ import (
 
 // ScriptContext holds state for script execution within a single trigger.
 type ScriptContext struct {
-	Player   *Player
-	Room     *gameworld.Room
-	Engine   *GameEngine
-	Messages []string // ECHO PLAYER messages to send to the player
-	RoomMsgs []string // ECHO ALL / ECHO OTHERS messages for the room
-	GMMsgs   []string // GMMSG messages for gamemasters
-	Blocked      bool // CLEARVERB: block the triggering action
-	MoveTo       int  // MOVE: destination room (0 = no move)
-	MoveGroupTo  int  // MOVEGROUP: move all players in room to destination
+	Player      *Player
+	Room        *gameworld.Room
+	Engine      *GameEngine
+	Messages    []string // ECHO PLAYER messages to send to the player
+	RoomMsgs    []string // ECHO ALL / ECHO OTHERS messages for the room
+	GMMsgs      []string // GMMSG messages for gamemasters
+	Blocked     bool     // CLEARVERB: block the triggering action
+	MoveTo      int      // MOVE: destination room (0 = no move)
+	MoveGroupTo int      // MOVEGROUP: move all players in room to destination
 
-	StrVars  map[int]string // %0-%9 from STRCVT
+	StrVars  map[int]string  // %0-%9 from STRCVT
 	OrigRoom *gameworld.Room // saved room for AFFECT
 
 	// Item interaction context (set when running IFPREVERB/IFVERB on a room item)
@@ -713,10 +713,14 @@ func (sc *ScriptContext) getVar(name string) int {
 			return 0
 		}
 		switch idx {
-		case 1: return sc.Player.Flag1
-		case 2: return sc.Player.Flag2
-		case 3: return sc.Player.Flag3
-		case 4: return sc.Player.Flag4
+		case 1:
+			return sc.Player.Flag1
+		case 2:
+			return sc.Player.Flag2
+		case 3:
+			return sc.Player.Flag3
+		case 4:
+			return sc.Player.Flag4
 		}
 		return 0
 	}
@@ -739,23 +743,46 @@ func (sc *ScriptContext) getVar(name string) int {
 	case "RAC":
 		return sc.Player.Race
 	case "MISTFORM":
-		if sc.Player.Race == 8 { return 1 }
+		if sc.Player.Race == 8 {
+			return 1
+		}
 		return 0
 	// Player stats
-	case "STR", "STRT":
+	// case "STR" returns the base strength, while "STRT" returns the effective strength after modifiers.
+	case "STR":
 		return sc.Player.Strength
-	case "AGI", "AGIT":
+	case "STRT":
+		return sc.Player.EffectiveStat(StatStrength)
+
+	case "AGI":
 		return sc.Player.Agility
-	case "CON", "CONT":
+	case "AGIT":
+		return sc.Player.EffectiveStat(StatAgility)
+
+	case "CON":
 		return sc.Player.Constitution
-	case "QUI", "QUIT":
+	case "CONT":
+		return sc.Player.EffectiveStat(StatConstitution)
+
+	case "QUI":
 		return sc.Player.Quickness
-	case "WIL", "WILT":
+	case "QUIT":
+		return sc.Player.EffectiveStat(StatQuickness)
+
+	case "WIL":
 		return sc.Player.Willpower
-	case "PER", "PERT":
+	case "WILT":
+		return sc.Player.EffectiveStat(StatWillpower)
+
+	case "PER":
 		return sc.Player.Perception
-	case "EMP", "EMPT":
+	case "PERT":
+		return sc.Player.EffectiveStat(StatPerception)
+
+	case "EMP":
 		return sc.Player.Empathy
+	case "EMPT":
+		return sc.Player.EffectiveStat(StatEmpathy)
 	// Player resources
 	case "BODYPOINTS":
 		return sc.Player.BodyPoints
@@ -775,25 +802,39 @@ func (sc *ScriptContext) getVar(name string) int {
 		return sc.Player.MaxPsi
 	// Player state
 	case "DEAD":
-		if sc.Player.Dead { return 1 }
+		if sc.Player.Dead {
+			return 1
+		}
 		return 0
 	case "FLYING":
-		if sc.Player.Position == 4 { return 1 }
+		if sc.Player.Position == 4 {
+			return 1
+		}
 		return 0
 	case "KNEELING":
-		if sc.Player.Position == 3 { return 1 }
+		if sc.Player.Position == 3 {
+			return 1
+		}
 		return 0
 	case "LAYING":
-		if sc.Player.Position == 2 { return 1 }
+		if sc.Player.Position == 2 {
+			return 1
+		}
 		return 0
 	case "SITTING":
-		if sc.Player.Position == 1 { return 1 }
+		if sc.Player.Position == 1 {
+			return 1
+		}
 		return 0
 	case "STANDING":
-		if sc.Player.Position == 0 { return 1 }
+		if sc.Player.Position == 0 {
+			return 1
+		}
 		return 0
 	case "HIDDEN":
-		if sc.Player.Hidden { return 1 }
+		if sc.Player.Hidden {
+			return 1
+		}
 		return 0
 	// Organization
 	case "ORG":
@@ -806,22 +847,30 @@ func (sc *ScriptContext) getVar(name string) int {
 		return sc.Player.BuildPoints
 	// Wielded
 	case "WIELDED":
-		if sc.Player.Wielded != nil { return 1 }
+		if sc.Player.Wielded != nil {
+			return 1
+		}
 		return 0
 	case "ARCHNUM":
-		if sc.Player.Wielded != nil { return sc.Player.Wielded.Archetype }
+		if sc.Player.Wielded != nil {
+			return sc.Player.Wielded.Archetype
+		}
 		return 0
 	// Room info
 	case "RNUM":
 		return sc.Player.RoomNumber
 	case "OUTDOOR":
-		if sc.Room != nil && isOutdoorTerrain(sc.Room.Terrain) { return 1 }
+		if sc.Room != nil && isOutdoorTerrain(sc.Room.Terrain) {
+			return 1
+		}
 		return 0
 	case "PLRSINROOM":
 		if sc.Engine.sessions != nil {
 			count := 0
 			for _, p := range sc.Engine.sessions.OnlinePlayers() {
-				if p.RoomNumber == sc.Player.RoomNumber { count++ }
+				if p.RoomNumber == sc.Player.RoomNumber {
+					count++
+				}
 			}
 			return count
 		}
@@ -835,10 +884,14 @@ func (sc *ScriptContext) getVar(name string) int {
 	case "TIM":
 		return GameHour()
 	case "DAY":
-		if IsDay() { return 1 }
+		if IsDay() {
+			return 1
+		}
 		return 0
 	case "NIGHT":
-		if IsNight() { return 1 }
+		if IsNight() {
+			return 1
+		}
 		return 0
 	case "DATE":
 		return GameDay()
@@ -870,25 +923,39 @@ func (sc *ScriptContext) getVar(name string) int {
 		return sc.Player.AgeTrue
 	// Form states
 	case "WOLFFORM":
-		if sc.Player.WolfForm { return 1 }
+		if sc.Player.WolfForm {
+			return 1
+		}
 		return 0
 	case "SLIMEFORM":
-		if sc.Player.SlimeForm { return 1 }
+		if sc.Player.SlimeForm {
+			return 1
+		}
 		return 0
 	case "OTHERFORM":
-		if sc.Player.WolfForm || sc.Player.SlimeForm || (sc.Player.Race == 8 && sc.Player.Hidden) { return 1 }
+		if sc.Player.WolfForm || sc.Player.SlimeForm || (sc.Player.Race == 8 && sc.Player.Hidden) {
+			return 1
+		}
 		return 0
 	case "UNDEAD":
-		if sc.Player.Undead { return 1 }
+		if sc.Player.Undead {
+			return 1
+		}
 		return 0
 	case "DISGUISED":
-		if sc.Player.Disguised { return 1 }
+		if sc.Player.Disguised {
+			return 1
+		}
 		return 0
 	case "SLEEPING":
-		if sc.Player.Sleeping { return 1 }
+		if sc.Player.Sleeping {
+			return 1
+		}
 		return 0
 	case "SUBMITTING":
-		if sc.Player.Submitting { return 1 }
+		if sc.Player.Submitting {
+			return 1
+		}
 		return 0
 	case "ROUNDTIME":
 		return sc.Player.RoundTime
@@ -909,7 +976,9 @@ func (sc *ScriptContext) getVar(name string) int {
 		}
 		return 0
 	case "ASTRAL":
-		if sc.Room != nil && sc.Room.Terrain == "ASTRAL" { return 1 }
+		if sc.Room != nil && sc.Room.Terrain == "ASTRAL" {
+			return 1
+		}
 		return 0
 	case "TERRAIN":
 		if sc.Room != nil {
@@ -940,7 +1009,9 @@ func (sc *ScriptContext) getVar(name string) int {
 	case "WEALTH2", "WEALTH3", "WEALTH4", "WEALTH5", "WEALTH6", "WEALTH7", "WEALTH8", "WEALTH9":
 		return 0 // TODO: multi-currency per region
 	case "OBJWEIGHT":
-		if sc.ItemDef != nil { return sc.ItemDef.Weight }
+		if sc.ItemDef != nil {
+			return sc.ItemDef.Weight
+		}
 		return 0
 	case "PLAYERNUM":
 		return 0 // TODO: unique player number
@@ -1017,10 +1088,14 @@ func (sc *ScriptContext) setVar(name string, val int) {
 	if strings.HasPrefix(name, "FLAG") {
 		idx, _ := strconv.Atoi(name[4:])
 		switch idx {
-		case 1: sc.Player.Flag1 = val
-		case 2: sc.Player.Flag2 = val
-		case 3: sc.Player.Flag3 = val
-		case 4: sc.Player.Flag4 = val
+		case 1:
+			sc.Player.Flag1 = val
+		case 2:
+			sc.Player.Flag2 = val
+		case 3:
+			sc.Player.Flag3 = val
+		case 4:
+			sc.Player.Flag4 = val
 		}
 		return
 	}
@@ -1068,10 +1143,9 @@ func (sc *ScriptContext) setVar(name string, val int) {
 	}
 }
 
-
 // resolveNumericArg resolves a script argument that can be a literal number
 // or a variable reference like ITEMVAL2.
-func (sc *ScriptContext) resolveNumericArg(arg string) int {
+/*func (sc *ScriptContext) resolveNumericArg(arg string) int {
 	upper := strings.ToUpper(arg)
 	if strings.HasPrefix(upper, "ITEMVAL") {
 		return sc.getVar(upper)
@@ -1081,6 +1155,17 @@ func (sc *ScriptContext) resolveNumericArg(arg string) int {
 		return 0
 	}
 	return val
+}
+*/
+
+func (sc *ScriptContext) resolveNumericArg(arg string) int {
+	// First try a literal number.
+	if val, err := strconv.Atoi(arg); err == nil {
+		return val
+	}
+
+	// Otherwise treat it as a script variable.
+	return sc.getVar(strings.ToUpper(arg))
 }
 
 // expandScriptText replaces script placeholders in text.
@@ -1137,6 +1222,7 @@ func (sc *ScriptContext) doRandom(args []string) {
 }
 
 // doDamagePlr applies damage to the player.
+/*
 func (sc *ScriptContext) doDamagePlr(args []string) {
 	if len(args) < 2 {
 		return
@@ -1162,6 +1248,92 @@ func (sc *ScriptContext) doDamagePlr(args []string) {
 		text := strings.Join(args[idx+1:], " ")
 		sc.Messages = append(sc.Messages, sc.expandScriptText(text))
 	}
+} */
+
+func (sc *ScriptContext) doDamagePlr(args []string) {
+	if len(args) < 1 {
+		return
+	}
+
+	idx := 0
+	bodyOnly := false
+	damageType := ""
+
+	// Optional BODYONLY keyword.
+	if strings.EqualFold(args[idx], "BODYONLY") {
+		bodyOnly = true
+		idx++
+	}
+
+	if idx >= len(args) {
+		return
+	}
+
+	// Support both:
+	// DAMAGEPLR 15 message...
+	// DAMAGEPLR ELECTRIC 15 message...
+	if _, err := strconv.Atoi(args[idx]); err != nil {
+		damageType = strings.ToUpper(args[idx])
+		idx++
+	}
+
+	if idx >= len(args) {
+		return
+	}
+
+	/*amount, err := strconv.Atoi(args[idx])
+	if err != nil {
+		return
+	}
+	idx++  */
+
+	amount := sc.resolveNumericArg(args[idx])
+	idx++
+
+	finalDamage := amount
+
+	if !bodyOnly && damageType != "" {
+		finalDamage = sc.applyPlayerResistance(damageType, amount)
+	}
+
+	if finalDamage < 0 {
+		finalDamage = 0
+	}
+
+	sc.Player.BodyPoints -= finalDamage
+	if sc.Player.BodyPoints < 0 {
+		sc.Player.BodyPoints = 0
+	}
+
+	if idx < len(args) {
+		text := strings.Join(args[idx:], " ")
+		sc.Messages = append(sc.Messages, sc.expandScriptText(text))
+	}
+}
+
+func (sc *ScriptContext) applyPlayerResistance(damageType string, amount int) int {
+	resistance := 0
+
+	switch strings.ToUpper(damageType) {
+	case "BURN", "FIRE":
+		resistance = 0 //todo: sc.Player.FireResistance
+	case "ELECTRIC", "LIGHTNING":
+		resistance = 0 //todo sc.Player.ElectricResistance
+	case "COLD", "ICE":
+		resistance = 0 //todo: sc.Player.ColdResistance
+	case "POISON":
+		resistance = 0 //todo: sc.Player.PoisonResistance
+	}
+
+	// Assuming resistance is a percentage from 0 to 100.
+	if resistance < 0 {
+		resistance = 0
+	}
+	if resistance > 100 {
+		resistance = 100
+	}
+
+	return amount * (100 - resistance) / 100
 }
 
 // doStrCvt converts a variable to a string for %0-%9 substitution.
@@ -1414,8 +1586,18 @@ func (sc *ScriptContext) expandScriptText(text string) string {
 		text = strings.ReplaceAll(text, "%i", "her")
 	}
 	// Legacy aliases
-	text = strings.ReplaceAll(text, "%e", func() string { if sc.Player.Gender == 0 { return "he" }; return "she" }())
-	text = strings.ReplaceAll(text, "%o", func() string { if sc.Player.Gender == 0 { return "him" }; return "her" }())
+	text = strings.ReplaceAll(text, "%e", func() string {
+		if sc.Player.Gender == 0 {
+			return "he"
+		}
+		return "she"
+	}())
+	text = strings.ReplaceAll(text, "%o", func() string {
+		if sc.Player.Gender == 0 {
+			return "him"
+		}
+		return "her"
+	}())
 	// STRCVT %0-%9
 	if sc.StrVars != nil {
 		for i := 0; i <= 9; i++ {

--- a/engine/internal/engine/spells.go
+++ b/engine/internal/engine/spells.go
@@ -15,7 +15,7 @@ type SpellDef struct {
 	School   string
 	Level    int
 	ManaCost int
-	CastTime int // seconds
+	CastTime int    // seconds
 	Effect   string // "damage", "heal", "defense", "buff", "utility"
 	DmgMin   int
 	DmgMax   int
@@ -72,9 +72,9 @@ func init() {
 		{ID: 200, Name: "Fear", School: "Enchantment", Level: 1, ManaCost: 3, CastTime: 3, Effect: "utility"},
 		{ID: 201, Name: "Charm", School: "Enchantment", Level: 3, ManaCost: 8, CastTime: 3, Effect: "utility"},
 		{ID: 202, Name: "Enchantment I", School: "Enchantment", Level: 5, ManaCost: 10, CastTime: 4, Effect: "buff"},
-		{ID: 207, Name: "Strength I", School: "Enchantment", Level: 4, ManaCost: 6, CastTime: 3, Effect: "buff"},
-		{ID: 208, Name: "Strength II", School: "Enchantment", Level: 8, ManaCost: 10, CastTime: 3, Effect: "buff"},
-		{ID: 209, Name: "Strength III", School: "Enchantment", Level: 16, ManaCost: 18, CastTime: 3, Effect: "buff"},
+		{ID: 207, Name: "Strength I", School: "Enchantment", Level: 4, ManaCost: 6, CastTime: 3, Effect: "buff", DefBonus: 10},
+		{ID: 208, Name: "Strength II", School: "Enchantment", Level: 8, ManaCost: 10, CastTime: 3, Effect: "buff", DefBonus: 20},
+		{ID: 209, Name: "Strength III", School: "Enchantment", Level: 16, ManaCost: 18, CastTime: 3, Effect: "buff", DefBonus: 30},
 		{ID: 210, Name: "Haste", School: "Enchantment", Level: 5, ManaCost: 8, CastTime: 3, Effect: "buff"},
 		{ID: 211, Name: "Slow", School: "Enchantment", Level: 5, ManaCost: 8, CastTime: 3, Effect: "utility"},
 		{ID: 216, Name: "Slumber I", School: "Enchantment", Level: 2, ManaCost: 4, CastTime: 3, Effect: "utility"},
@@ -127,9 +127,9 @@ func init() {
 		{ID: 508, Name: "Cold Shield", School: "Druidic", Level: 6, ManaCost: 8, CastTime: 3, Effect: "buff"},
 		{ID: 511, Name: "Carapace", School: "Druidic", Level: 8, ManaCost: 10, CastTime: 3, Effect: "defense", DefBonus: 20},
 		{ID: 512, Name: "True Aim", School: "Druidic", Level: 15, ManaCost: 18, CastTime: 3, Effect: "buff"},
-		{ID: 513, Name: "Agility I", School: "Druidic", Level: 4, ManaCost: 6, CastTime: 3, Effect: "buff"},
-		{ID: 514, Name: "Agility II", School: "Druidic", Level: 11, ManaCost: 12, CastTime: 3, Effect: "buff"},
-		{ID: 515, Name: "Agility III", School: "Druidic", Level: 16, ManaCost: 20, CastTime: 3, Effect: "buff"},
+		{ID: 513, Name: "Agility I", School: "Druidic", Level: 4, ManaCost: 6, CastTime: 3, Effect: "buff", DefBonus: 10},
+		{ID: 514, Name: "Agility II", School: "Druidic", Level: 11, ManaCost: 12, CastTime: 3, Effect: "buff", DefBonus: 20},
+		{ID: 515, Name: "Agility III", School: "Druidic", Level: 16, ManaCost: 20, CastTime: 3, Effect: "buff", DefBonus: 30},
 		{ID: 519, Name: "Sunray", School: "Druidic", Level: 13, ManaCost: 18, CastTime: 3, Effect: "damage", DmgMin: 12, DmgMax: 35, DmgType: "heat"},
 		{ID: 520, Name: "Night Vision", School: "Druidic", Level: 1, ManaCost: 2, CastTime: 2, Effect: "utility"},
 		{ID: 521, Name: "Camouflage", School: "Druidic", Level: 7, ManaCost: 8, CastTime: 3, Effect: "buff"},
@@ -189,6 +189,110 @@ func spellSchoolSkill(school string) int {
 		return 17
 	default:
 		return 23
+	}
+}
+
+// doLearn handles the LEARN command — learn a spell from a scroll.
+// The scroll's Val3 holds the spell number. The player must have the
+// appropriate magic school skill at a sufficient level.
+func (e *GameEngine) doLearn(ctx context.Context, player *Player, args []string) *CommandResult {
+	if len(args) == 0 {
+		return &CommandResult{Messages: []string{"Learn from what?"}}
+	}
+	target := strings.ToLower(strings.Join(args, " "))
+	target = strings.TrimPrefix(target, "my ")
+	target, ordSkip := parseOrdinal(target)
+	skip := ordSkip
+
+	for i, ii := range player.Inventory {
+		itemDef := e.items[ii.Archetype]
+		if itemDef == nil {
+			continue
+		}
+		if !strings.Contains(strings.ToUpper(itemDef.Type), "SCROLL") {
+			continue
+		}
+		name := e.getItemNounName(itemDef)
+		if !matchesTarget(name, target, e.getAdjName(ii.Adj1)) {
+			continue
+		}
+		if skip > 0 {
+			skip--
+			continue
+		}
+
+		spellNum := ii.Val3
+		if spellNum == 0 {
+			return &CommandResult{Messages: []string{"This scroll holds no magical inscription."}}
+		}
+
+		spell := FindSpellByID(spellNum)
+		if spell == nil {
+			return &CommandResult{Messages: []string{"The scroll's magic is beyond comprehension."}}
+		}
+
+		// Check if already known
+		if player.KnownSpells != nil {
+			if _, known := player.KnownSpells[spellNum]; known {
+				return &CommandResult{Messages: []string{fmt.Sprintf("You already know %s.", spell.Name)}}
+			}
+		}
+
+		// Map spell school name to required skill ID
+		requiredSkill := schoolSkillID(spell.School)
+		if requiredSkill < 0 {
+			return &CommandResult{Messages: []string{"You cannot learn spells of that school."}}
+		}
+
+		// Player must have the school skill at a level >= spell level
+		playerSkillLevel := player.Skills[requiredSkill]
+		if playerSkillLevel < spell.Level {
+			return &CommandResult{Messages: []string{
+				fmt.Sprintf("You need %s rank %d to learn %s (you have rank %d).",
+					SkillNames[requiredSkill], spell.Level, spell.Name, playerSkillLevel),
+			}}
+		}
+
+		// Consume the scroll and add the spell
+		fullName := e.formatItemName(itemDef, ii.Adj1, ii.Adj2, ii.Adj3)
+		player.Inventory = append(player.Inventory[:i], player.Inventory[i+1:]...)
+		if player.KnownSpells == nil {
+			player.KnownSpells = make(map[int]bool)
+		}
+		player.KnownSpells[spellNum] = true
+
+		player.RoundTimeExpiry = time.Now().Add(5 * time.Second)
+		e.SavePlayer(ctx, player)
+		return &CommandResult{
+			Messages: []string{
+				fmt.Sprintf("You study %s carefully...", fullName),
+				fmt.Sprintf("You learn %s! The scroll crumbles to dust.", spell.Name),
+				"[Round: 5 sec]",
+			},
+			RoomBroadcast: []string{
+				fmt.Sprintf("%s studies a scroll, which crumbles away.", player.FirstName),
+			},
+		}
+	}
+	return &CommandResult{Messages: []string{"You don't have that."}}
+}
+
+// schoolSkillID returns the skill ID required for a given magic school name.
+// Returns -1 if the school is unknown.
+func schoolSkillID(school string) int {
+	switch strings.ToLower(school) {
+	case "conjuration":
+		return 7
+	case "enchantment":
+		return 14
+	case "druidic":
+		return 17
+	case "general":
+		return 23 // Spellcraft
+	case "necromancy":
+		return 30
+	default:
+		return -1
 	}
 }
 
@@ -275,7 +379,7 @@ func (e *GameEngine) doCastSpell(ctx context.Context, player *Player, args []str
 	// Base 25% + EMP/10 + spellcraft*5%, max 95%.
 	// Roll > 98 = fumble. Roll <= 2 = spectacular success (double effect).
 	spellcraftSkill := player.Skills[23]
-	castChance := 25 + player.Empathy/10 + spellcraftSkill*5
+	castChance := 25 + player.EffectiveStat(StatEmpathy)/10 + spellcraftSkill*5
 	if castChance > 95 {
 		castChance = 95
 	}
@@ -316,7 +420,7 @@ func (e *GameEngine) doCastSpell(ctx context.Context, player *Player, args []str
 		result = e.castDamageSpell(player, spell, args, spectacularSuccess)
 	case "heal":
 		result = e.castHealSpell(ctx, player, spell, args)
-	case "defense":
+	case "defense": //todo: add defensive spell effects to player stats
 		player.DefenseBonus += spell.DefBonus
 		result.Messages = []string{fmt.Sprintf("You gesture and %s takes effect! (+%d defense)", spell.Name, spell.DefBonus)}
 		result.RoomBroadcast = []string{fmt.Sprintf("%s gestures and casts %s.", player.FirstName, spell.Name)}
@@ -483,6 +587,10 @@ func (e *GameEngine) castHealSpell(ctx context.Context, player *Player, spell *S
 
 func (e *GameEngine) castBuffSpell(player *Player, spell *SpellDef, args []string) *CommandResult {
 	msg := fmt.Sprintf("You gesture and cast %s.", spell.Name)
+
+	//fixed duration right now
+	buffDuration := 5 * time.Minute
+
 	switch spell.ID {
 	case 202: // Enchantment I — enchant a weapon in inventory
 		if len(args) == 0 {
@@ -512,15 +620,16 @@ func (e *GameEngine) castBuffSpell(player *Player, spell *SpellDef, args []strin
 		}
 		return &CommandResult{Messages: []string{"You don't have a weapon matching that."}}
 	case 207: // Strength I
-		player.Strength += 10
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, StatStrength, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. You feel stronger! (+10 STR)", spell.Name)
 	case 208: // Strength II
-		player.Strength += 20
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, StatStrength, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. You feel much stronger! (+20 STR)", spell.Name)
 	case 209: // Strength III
-		player.Strength += 30
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, StatStrength, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. Immense strength surges through you! (+30 STR)", spell.Name)
 	case 210: // Haste
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, HasteBuff, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. The world seems to slow down around you.", spell.Name)
 	case 224: // Fly
 		player.CanFly = true
@@ -529,13 +638,13 @@ func (e *GameEngine) castBuffSpell(player *Player, spell *SpellDef, args []strin
 		player.Invisible = true
 		msg = fmt.Sprintf("You gesture and cast %s. You fade from sight.", spell.Name)
 	case 513: // Agility I
-		player.Agility += 10
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, StatAgility, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. You feel more agile! (+10 AGI)", spell.Name)
 	case 514: // Agility II
-		player.Agility += 20
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, StatAgility, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. You feel much more agile! (+20 AGI)", spell.Name)
 	case 515: // Agility III
-		player.Agility += 30
+		player.ApplyStatEffect(spell.ID, EffectSourceSpell, StatAgility, spell.DefBonus, buffDuration)
 		msg = fmt.Sprintf("You gesture and cast %s. Incredible agility flows through you! (+30 AGI)", spell.Name)
 	}
 	return &CommandResult{

--- a/original/scripts-older/FAYD.SCR
+++ b/original/scripts-older/FAYD.SCR
@@ -1925,6 +1925,14 @@ EXIT SE 291
 EXIT SW 290
 EXIT ABOVE 2152
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
+IFVERB TOUCH 0
+  RANDOM DUMMY1 10
+  ADD DUMMY1 1
+  STRCVT 0 DUMMY1
+  ECHO PLAYER A bolt of lightning leaps from the black gate and strikes you for %0 damage!
+  ECHO OTHERS A bolt of lightning leaps from the black gate and strikes %N!
+  DAMAGEPLR ELECTRIC DUMMY1
+ENDIF
 ;
 NUMBER 290
 NAME Poor Quarter

--- a/original/scripts-older/FAYDFALL.SCR
+++ b/original/scripts-older/FAYDFALL.SCR
@@ -1772,7 +1772,14 @@ EXIT SW 290
 EXIT ABOVE 2152
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
 ITEM 9 693 ADJ1=10
-
+IFVERB TOUCH 0
+  RANDOM DUMMY1 10
+  ADD DUMMY1 1
+  STRCVT 0 DUMMY1
+  ECHO PLAYER A bolt of lightning leaps from the black gate and strikes you for %0 damage!
+  ECHO OTHERS A bolt of lightning leaps from the black gate and strikes %N!
+  DAMAGEPLR ELECTRIC DUMMY1
+ENDIF
 ;
 NUMBER 290
 NAME Poor Quarter

--- a/original/scripts/FAYD.SCR
+++ b/original/scripts/FAYD.SCR
@@ -393,7 +393,7 @@ There is a manuscript detailing the items for sale by the Armorers Guild here.
 *DESCRIPTION_START ITEM READ 1
 Weapons             Price            Weapons             Price
 ----                -----            ----                -----
-Axe                3 Crowns          Long Sword        27 Crowns
+Axe1               3 Crowns          Long Sword        27 Crowns
 Battleaxe         12 Crowns          Mace              10 Crowns
 Dagger             2 Crowns          Morning Star      15 Crowns
 Glaive            17 Crowns          Pike              25 Crowns
@@ -1918,13 +1918,20 @@ MONSTER_GROUP 2
 DAY_LIGHT
 CALL 33
 *DESCRIPTION_START
-Boards have been nailed across the door of the old Temple of Kaliban, preventing entry. Small particles of wood and sawdust lie at the base of a sawed-off stump. There is a small sign tacked up across the boards.
+Boards1 have been nailed across the door of the old Temple of Kaliban, preventing entry. Small particles of wood and sawdust lie at the base of a sawed-off stump. There is a small sign tacked up across the boards.
 *DESCRIPTION_END
 EXIT W 288
 EXIT SE 291
 EXIT SW 290
 EXIT ABOVE 2152
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
+
+IFTOUCH 0
+    ECHO OTHERS %N touches the black metal gate...
+    ECHO PLAYER You touch the black metal gate...
+    DAMAGE ELECTRIC 15 %N is struck by an arc of lightning from the gate!
+    CLEARVERB
+ENDIF
 ;
 NUMBER 290
 NAME Poor Quarter

--- a/original/scripts/FAYDFALL.SCR
+++ b/original/scripts/FAYDFALL.SCR
@@ -1764,7 +1764,7 @@ MONSTER_GROUP 2
 DAY_LIGHT
 CALL 33
 *DESCRIPTION_START
-Boards have been nailed across the door of the old Temple of Kaliban, preventing entry. Small particles of wood and sawdust lie at the base of a sawed-off stump. There is a small sign tacked up across the boards.
+Boards3 have been nailed across the door of the old Temple of Kaliban, preventing entry. Small particles of wood and sawdust lie at the base of a sawed-off stump. There is a small sign tacked up across the boards.
 *DESCRIPTION_END
 EXIT W 288
 EXIT SE 291
@@ -1772,6 +1772,12 @@ EXIT SW 290
 EXIT ABOVE 2152
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
 ITEM 9 693 ADJ1=10
+IFTOUCH 0
+    ECHO OTHERS %N touches the black metal gate...
+    ECHO PLAYER You touch the black metal gate...
+    DAMAGE ELECTRIC 15 %N is struck by an arc of lightning from the gate!
+    CLEARVERB
+ENDIF
 
 ;
 NUMBER 290

--- a/original/scripts/FAYDINDR.SCR
+++ b/original/scripts/FAYDINDR.SCR
@@ -1415,6 +1415,7 @@ The Adventurers' Guild is the oldest organization in Fayd. It was founded with t
 EXIT O 275
 ITEM 0 1226 VAL2=225
 ITEM 9 693 ADJ1=10
+ITEM 0 168 ADJ1= 200 VAL1=6500 VAL3=513
 
 IFENTRY
 	IFVAR INTNUM6 = 2

--- a/original/scripts/FAYDSPRI.SCR
+++ b/original/scripts/FAYDSPRI.SCR
@@ -1760,6 +1760,15 @@ EXIT SE 291
 EXIT SW 290
 EXIT ABOVE 2152
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
+ITEM 0 168 ADJ1=292 VAL1=10000 VAL3=105
+IFVERB TOUCH 0
+  RANDOM DUMMY1 10
+  ADD DUMMY1 1
+  STRCVT 0 DUMMY1
+  ECHO PLAYER A bolt of lightning leaps from the black gate and strikes you for %0 damage!
+  ECHO OTHERS A bolt of lightning leaps from the black gate and strikes %N!
+  DAMAGEPLR ELECTRIC DUMMY1
+ENDIF
 ;
 NUMBER 290
 NAME Poor Quarter

--- a/original/scripts/FAYDSUM.SCR
+++ b/original/scripts/FAYDSUM.SCR
@@ -1850,7 +1850,7 @@ MONSTER_GROUP 2
 DAY_LIGHT
 CALL 33
 *DESCRIPTION_START
-Boards have been nailed across the door of the old Temple of Kaliban, preventing entry. Small particles of wood and sawdust lie at the base of a sawed-off stump. There is a small sign tacked up across the boards.
+Boards 4have been nailed across the door of the old Temple of Kaliban, preventing entry. Small particles of wood and sawdust lie at the base of a sawed-off stump. There is a small sign tacked up across the boards.
 *DESCRIPTION_END
 EXIT W 288
 EXIT SE 291
@@ -1859,6 +1859,13 @@ EXIT ABOVE 2152
 ITEM 9 693 ADJ1=10
 
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
+
+IFTOUCH 0
+    ECHO OTHERS %N touches the black metal gate...
+    ECHO PLAYER You touch the black metal gate...
+    DAMAGE ELECTRIC 15 %N is struck by an arc of lightning from the gate!
+    CLEARVERB
+ENDIF
 ;
 NUMBER 290
 NAME Poor Quarter
@@ -1908,6 +1915,7 @@ EXIT N 291
 EXIT SW 294
 EXIT ABOVE 2152
 ITEM 9 693 ADJ1=10
+
 
 ;
 NUMBER 294

--- a/original/scripts/FAYDWIN.SCR
+++ b/original/scripts/FAYDWIN.SCR
@@ -1788,6 +1788,14 @@ EXIT SE 291
 EXIT SW 290
 EXIT ABOVE 2152
 ITEM 0 68 ADJ1=25 ADJ2=192 VAL2=2605
+IFVERB TOUCH 0
+  RANDOM DUMMY1 10
+  ADD DUMMY1 1
+  STRCVT 0 DUMMY1
+  ECHO PLAYER A bolt of lightning leaps from the black gate and strikes you for %0 damage!
+  ECHO OTHERS A bolt of lightning leaps from the black gate and strikes %N!
+  DAMAGEPLR ELECTRIC DUMMY1
+ENDIF
 ;
 NUMBER 290
 NAME Poor Quarter


### PR DESCRIPTION
Temporary spell and status modifiers are now stored in the player's active effect list rather than written directly into the base stat fields. EffectiveStat() calculates the current value by combining the permanent base stat with modifiers from those active effects.

This prevents buffs and debuffs from permanently changing the character's underlying stats while still allowing them to affect combat, crafting, searching, psionics, and script checks.

Gameplay systems now use EffectiveStat() whenever a calculation should consider active buffs or debuffs, while scripts can explicitly choose between base stats (STR, AGI, etc.) and effective stats (STRT, AGIT, etc.). This preserves the original stat values while allowing temporary modifiers to affect gameplay as intended.

It also builds the foundation to stack effects and/or debuffs in the future..   (Invisibility, slow, flying etc... can all now be added to the queue with a duration)

Also includes the black gate script update to apply randomized electric damage on touch. (because i was a druid and had ride the lightning)

Changes include:

* Combat roundtime now uses effective Quickness.
* Mining success now uses effective Strength.
* Search detection now uses effective Perception.
* Psionic checks now use effective Willpower.
* Script variables now distinguish base stats from effective stats:
* generic 5 minute duration for all cast buff spells (agility, str, etc) -- Todo: add duration to spell description and pull from there

  * `STR`, `AGI`, `CON`, `QUI`, `WIL`, `PER`, `EMP` return base values.
  * `STRT`, `AGIT`, `CONT`, `QUIT`, `WILT`, `PERT`, `EMPT` return effective values.

* Adds black-gate electric damage script behavior to the Fayde script variants.

 Temporary spell/stat modifiers
ActiveStatEffects []StatEffect `bson:"activeStatEffects,omitempty" json:"activeStatEffects,omitempty"`
