### PR TITLE
Improve creature skinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ engine/lofp
 VIBECTL.md
 .vscode/
 __debug_bin*
+start.bat

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ frontend/node_modules/
 *.log
 engine/lofp
 VIBECTL.md
+.vscode/
+__debug_bin*

--- a/engine/internal/engine/engine.go
+++ b/engine/internal/engine/engine.go
@@ -6036,34 +6036,50 @@ func (e *GameEngine) doSkin(ctx context.Context, player *Player, args []string) 
 	if len(args) == 0 {
 		return &CommandResult{Messages: []string{"Skin what?"}}
 	}
-	target := strings.ToLower(strings.Join(args, " "))
 
-	// Find a dead monster in the room
+	rawTarget := strings.ToLower(strings.Join(args, " "))
+	target, ordSkip := parseOrdinal(rawTarget)
+
 	if e.monsterMgr == nil {
 		return &CommandResult{Messages: []string{"You don't see that here."}}
 	}
 
+	matchCount := 0
 	monsters := e.monsterMgr.AllMonstersInRoom(player.RoomNumber)
+
 	for _, inst := range monsters {
 		if inst.Alive {
-			continue // can only skin dead monsters
+			continue
 		}
+
 		def := e.monsters[inst.DefNumber]
 		if def == nil {
 			continue
 		}
+
 		name := strings.ToLower(FormatMonsterName(def, e.monAdjs))
 		noun := strings.ToLower(def.Name)
-		if !strings.HasPrefix(name, target) && !strings.HasPrefix(noun, target) {
+
+		if !strings.HasPrefix(name, target) &&
+			!strings.HasPrefix(noun, target) {
+			continue
+		}
+
+		matchCount++
+		if matchCount <= ordSkip {
 			continue
 		}
 
 		if def.Discorporate {
-			return &CommandResult{Messages: []string{"There is nothing left to skin."}}
+			return &CommandResult{
+				Messages: []string{"There is nothing left to skin."},
+			}
 		}
 
 		if inst.Skinned {
-			return &CommandResult{Messages: []string{"This corpse has already been skinned."}}
+			return &CommandResult{
+				Messages: []string{"This corpse has already been skinned."},
+			}
 		}
 
 		// Check for skin items
@@ -6108,7 +6124,6 @@ func (e *GameEngine) doSkin(ctx context.Context, player *Player, args []string) 
 			skinMsgs = append(skinMsgs, fmt.Sprintf("You skin %s %s but find nothing useful.", articleFor(displayName, def.Unique), displayName))
 		}
 
-		inst.Skinned = true
 		e.monsterMgr.MarkSkinned(inst.ID)
 		e.SavePlayer(ctx, player)
 		return &CommandResult{

--- a/engine/internal/engine/engine.go
+++ b/engine/internal/engine/engine.go
@@ -6109,6 +6109,7 @@ func (e *GameEngine) doSkin(ctx context.Context, player *Player, args []string) 
 		}
 
 		inst.Skinned = true
+		e.monsterMgr.MarkSkinned(inst.ID)
 		e.SavePlayer(ctx, player)
 		return &CommandResult{
 			Messages:      skinMsgs,

--- a/engine/internal/engine/monsters.go
+++ b/engine/internal/engine/monsters.go
@@ -20,10 +20,10 @@ type MonsterInstance struct {
 	Stunned      bool      `json:"-"` // stunned: skip next combat tick, easier to hit
 	Skinned      bool      `json:"-"` // already skinned
 	DefenseBonus int       `json:"-"` // from active psi defenses
-	CurrentHP  int       `json:"currentHP"`
-	Target     string    `json:"-"`
-	Searched   bool      `json:"-"` // already searched for loot
-	DeathTime  time.Time `json:"-"` // when it died (for corpse decay)
+	CurrentHP    int       `json:"currentHP"`
+	Target       string    `json:"-"`
+	Searched     bool      `json:"-"` // already searched for loot
+	DeathTime    time.Time `json:"-"` // when it died (for corpse decay)
 }
 
 // monsterManager handles monster spawning and tracking.
@@ -31,7 +31,7 @@ type monsterManager struct {
 	mu             sync.RWMutex
 	instances      []MonsterInstance
 	nextID         int
-	monstersByRoom map[int][]int    // roomNumber -> slice of instance indices
+	monstersByRoom map[int][]int     // roomNumber -> slice of instance indices
 	roomLastPlayer map[int]time.Time // roomNumber -> last time a player was present
 }
 
@@ -231,6 +231,26 @@ func (mm *monsterManager) AllMonstersInRoom(roomNum int) []MonsterInstance {
 		}
 	}
 	return result
+}
+
+func (mm *monsterManager) MarkSkinned(instanceID int) bool {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+
+	for i := range mm.instances {
+		if mm.instances[i].ID != instanceID {
+			continue
+		}
+
+		if mm.instances[i].Skinned {
+			return false
+		}
+
+		mm.instances[i].Skinned = true
+		return true
+	}
+
+	return false
 }
 
 // moveMonster moves a monster instance to a new room. Must be called under lock.


### PR DESCRIPTION
This PR improves the creature skinning system by fixing several gameplay and usability issues.

Changes include:
- Fixes creature skinning persistence.
- Adds ordinal targeting for the SKIN command (e.g. "skin 2 wolf").
- Fixes state handling and targeting edge cases during skinning.

This is a clean resubmission of the previously closed creature skinning work, rebased onto the current upstream main.